### PR TITLE
For Facebook and Twitter, leverage AS to find the user url and image.

### DIFF
--- a/cron.py
+++ b/cron.py
@@ -52,7 +52,8 @@ class UpdateTwitterPictures(webapp2.RequestHandler):
 
     for user in json.loads(users.read()):
       source = sources[user['screen_name']]
-      new_pic = Twitter.get_picture(user)
+      new_actor = auther.as_source.user_to_actor(user)
+      new_pic = new_actor.get('image', {}).get('url')
       if source.picture != new_pic:
         logging.info('Updating profile picture for %s from %s to %s',
                      source.bridgy_url(self), source.picture, new_pic)

--- a/facebook.py
+++ b/facebook.py
@@ -68,15 +68,14 @@ class FacebookPage(models.Source):
       kwargs: property values
     """
     user = json.loads(auth_entity.user_json)
-    id = user['id']
-    url = 'http://facebook.com/' + id
-    picture = ('http://graph.facebook.com/%s/picture?type=large' %
-               user.get('username', id))
-    return FacebookPage(id=id, type=user.get('type'),
-                        name=user.get('name'),
-                        username=user.get('username'),
+    as_source = as_facebook.Facebook(auth_entity.access_token())
+    actor = as_source.user_to_actor(user)
+    return FacebookPage(id=user['id'], type=user.get('type'),
                         auth_entity=auth_entity.key,
-                        picture=picture, url=url,
+                        name=actor.get('displayName'),
+                        username=actor.get('username'),
+                        picture=actor.get('image', {}).get('url'),
+                        url=actor.get('url'),
                         **kwargs)
 
   def get(self, url):


### PR DESCRIPTION
In the case of Twitter, we can move some special case handling to prefer https
and to grab larger pictures out of bridgy and into activitystreams.

Aesthetically, it feels a little weird to half-construct the Twitter and FacebookPage
objects before calling as_source.user_to_actor and then filling in the rest of the 
fields... is there a better way to handle that?
