### PR TITLE
posse-post-discovery: reduce number of NDB operations

### DIFF
--- a/original_post_discovery.py
+++ b/original_post_discovery.py
@@ -281,6 +281,8 @@ def _process_entry(source, permalink, refetch_blanks, preexisting):
   Args:
     permalink: url of the unprocessed post
     syndication_url: url of the syndicated content
+    refetch_blanks: boolean whether we should ignore blank preexisting
+      SyndicatedPosts
     preexisting: dict of original url to SyndicatedPost
 
   Return:


### PR DESCRIPTION
- do one query for all permalinks on a page, rather than querying
  for each permalink individually
- when refetching blanks, don't delete blanks unless we actually
  find something to replace them with (moved the deletion code
  to SyndicatedPost.get_or_insert... so that it's all part of
  the same transaction now)
