### PR TITLE
posse-post discovery for multiple rel=feeds

### DIFF
--- a/original_post_discovery.py
+++ b/original_post_discovery.py
@@ -196,7 +196,7 @@ def _process_author(source, author_url, refetch=False, store_blanks=True):
   feeditems = _find_feed_items(author_url, author_dom)
 
   # look for all other feed urls using rel='feed', type='text/html'
-  feed_urls = []
+  feed_urls = set()
   for rel_feed_node in (author_dom.find_all('link', rel='feed')
                         + author_dom.find_all('a', rel='feed')):
     feed_url = rel_feed_node.get('href')
@@ -215,8 +215,8 @@ def _process_author(source, author_url, refetch=False, store_blanks=True):
       logging.debug('author url is the feed url, ignoring')
     elif not feed_type_ok:
       logging.debug('skipping feed of type %s', feed_type)
-    elif feed_url not in feed_urls:
-      feed_urls.append(feed_url)
+    else:
+      feed_urls.add(feed_url)
 
   for feed_url in feed_urls:
     try:

--- a/original_post_discovery.py
+++ b/original_post_discovery.py
@@ -196,7 +196,7 @@ def _process_author(source, author_url, refetch=False, store_blanks=True):
   feeditems = _find_feed_items(author_url, author_dom)
 
   # look for all other feed urls using rel='feed', type='text/html'
-  feed_urls = set()
+  feed_urls = []
   for rel_feed_node in (author_dom.find_all('link', rel='feed')
                         + author_dom.find_all('a', rel='feed')):
     feed_url = rel_feed_node.get('href')
@@ -215,8 +215,8 @@ def _process_author(source, author_url, refetch=False, store_blanks=True):
       logging.debug('author url is the feed url, ignoring')
     elif not feed_type_ok:
       logging.debug('skipping feed of type %s', feed_type)
-    else:
-      feed_urls.add(feed_url)
+    elif feed_url not in feed_urls:
+      feed_urls.append(feed_url)
 
   for feed_url in feed_urls:
     try:
@@ -226,7 +226,6 @@ def _process_author(source, author_url, refetch=False, store_blanks=True):
       logging.debug("author's rel-feed fetched successfully %s", feed_url)
       feeditems = _merge_hfeeds(feeditems,
                                 _find_feed_items(feed_url, feed_resp.text))
-      break
     except AssertionError:
       raise  # reraise assertions for unit tests
     except BaseException:

--- a/original_post_discovery.py
+++ b/original_post_discovery.py
@@ -195,8 +195,8 @@ def _process_author(source, author_url, refetch=False, store_blanks=True):
   author_dom = BeautifulSoup(author_resp.text)
   feeditems = _find_feed_items(author_url, author_dom)
 
-  # look for canonical feed url (if it isn't this one) using
-  # rel='feed', type='text/html'
+  # look for all other feed urls using rel='feed', type='text/html'
+  feed_urls = set()
   for rel_feed_node in (author_dom.find_all('link', rel='feed')
                         + author_dom.find_all('a', rel='feed')):
     feed_url = rel_feed_node.get('href')
@@ -212,12 +212,13 @@ def _process_author(source, author_url, refetch=False, store_blanks=True):
       feed_type_ok = feed_type == 'text/html'
 
     if feed_url == author_url:
-      logging.debug('author url is the feed url, proceeding')
-      break
+      logging.debug('author url is the feed url, ignoring')
     elif not feed_type_ok:
       logging.debug('skipping feed of type %s', feed_type)
-      continue
+    else:
+      feed_urls.add(feed_url)
 
+  for feed_url in feed_urls:
     try:
       logging.debug("fetching author's rel-feed %s", feed_url)
       feed_resp = util.requests_get(feed_url)

--- a/test/test_original_post_discovery.py
+++ b/test/test_original_post_discovery.py
@@ -87,7 +87,7 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     <html class="h-feed">
       <div class="h-entry">
         <a class="u-url" href="http://author/post/permalink"></a>
-        <a class="u-syndication" href="http://fa.ke/post/url">
+        <a class="u-syndication" href="http://fa.ke/post/url"></a>
       </div>
     </html>""")
 
@@ -397,16 +397,16 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     self.expect_requests_get('http://author1', """
     <html class="h-feed">
       <div class="h-entry">
-        <a class="u-url" href="http://author1/A" />
-        <a class="u-syndication" href="http://fa.ke/A" />
+        <a class="u-url" href="http://author1/A"></a>
+        <a class="u-syndication" href="http://fa.ke/A"></a>
       </div>
     </html>""")
     self.expect_requests_get('http://author2').AndRaise(HTTPError())
     self.expect_requests_get('http://author3', """
     <html class="h-feed">
       <div class="h-entry">
-        <a class="u-url" href="http://author3/B" />
-        <a class="u-syndication" href="http://fa.ke/B" />
+        <a class="u-url" href="http://author3/B"></a>
+        <a class="u-syndication" href="http://fa.ke/B"></a>
       </div>
     </html>""")
     self.mox.ReplayAll()
@@ -578,6 +578,10 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
 
     # keep looking for an html feed
     self.expect_requests_head('http://author/updates.html')
+
+    # look at the rss feed last
+    self.expect_requests_head('http://author/updates.rss',
+                              content_type='application/xml')
 
     # now fetch the html feed
     self.expect_requests_get('http://author/updates.html', """
@@ -889,10 +893,10 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     <a class="h-entry" href="/permalink"></a>
     </html>"""
     hentry = """<html class="h-entry">
-    <a class="u-url" href="/permalink"/>
-    <a class="u-syndication" href="https://fa.ke/post/url1"/>
-    <a class="u-syndication" href="https://fa.ke/post/url3"/>
-    <a class="u-syndication" href="https://fa.ke/post/url5"/>
+    <a class="u-url" href="/permalink"></a>
+    <a class="u-syndication" href="https://fa.ke/post/url1"></a>
+    <a class="u-syndication" href="https://fa.ke/post/url3"></a>
+    <a class="u-syndication" href="https://fa.ke/post/url5"></a>
     </html>"""
 
     self.expect_requests_get('http://author', hfeed)
@@ -996,8 +1000,8 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     self.expect_requests_get('http://author', """
     <html class="h-feed">
       <div class="h-entry">
-        <a class="u-url" href="/permalink" />
-        <a class="u-syndication" href="http://fa.ke/changed/url" />
+        <a class="u-url" href="/permalink"></a>
+        <a class="u-syndication" href="http://fa.ke/changed/url"></a>
       </div>
     </html>""")
 
@@ -1016,7 +1020,7 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     self.expect_requests_get('http://author', """
     <html class="h-feed">
       <div class="h-entry">
-        <a class="u-url" href="/permalink" />
+        <a class="u-url" href="/permalink"></a>
       </div>
     </html>""")
     self.expect_requests_get('http://author/permalink', """
@@ -1037,7 +1041,7 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     self.expect_requests_get('http://author', """
     <html class="h-feed">
       <div class="h-entry">
-        <a class="u-url" href="/permalink" />
+        <a class="u-url" href="/permalink"></a>
       </div>
     </html>""")
     self.expect_requests_get('http://author/permalink', """
@@ -1059,8 +1063,8 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     self.expect_requests_get('http://author', """
     <html class="h-feed">
       <div class="h-entry">
-        <a class="u-url" href="/permalink" />
-        <a class="u-syndication" href="https://fa.ke/post/url" />
+        <a class="u-url" href="/permalink"></a>
+        <a class="u-syndication" href="https://fa.ke/post/url"></a>
       </div>
     </html>""")
 

--- a/test/test_original_post_discovery.py
+++ b/test/test_original_post_discovery.py
@@ -624,14 +624,14 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
       <article class="h-entry">
         <a class="u-url" href="/article-permalink"></a>
       </article>
-    </html>""")
+    </html>""").InAnyOrder('feed')
 
     self.expect_requests_get('http://author/notes', """
     <html class="h-feed">
       <article class="h-entry">
         <a class="u-url" href="/note-permalink"></a>
       </article>
-    </html>""")
+    </html>""").InAnyOrder('feed')
 
     # then the permalinks (in any order since they are hashed to
     # remove duplicates)
@@ -639,13 +639,13 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     <html class="h-entry">
       <a class="u-url" href="/article-permalink"></a>
       <a class="u-syndication" href="https://fa.ke/article"></a>
-    </html>""").InAnyOrder()
+    </html>""").InAnyOrder('permalink')
 
     self.expect_requests_get('http://author/note-permalink', """
     <html class="h-entry">
       <a class="u-url" href="/note-permalink"></a>
       <a class="u-syndication" href="https://fa.ke/note"></a>
-    </html>""").InAnyOrder()
+    </html>""").InAnyOrder('permalink')
 
     self.mox.ReplayAll()
     original_post_discovery.discover(self.source, self.activity)

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -66,9 +66,17 @@ class FakeBase(ndb.Model):
     return cls(id=id, **props)
 
 
+class FakeGrSourceMeta(FakeBase.__metaclass__,
+                       gr_source.Source.__metaclass__):
+  pass
+
+
 class FakeGrSource(FakeBase, gr_source.Source):
   NAME = 'FakeSource'
   DOMAIN = 'fa.ke'
+
+  __metaclass__ = FakeGrSourceMeta
+
 
   def user_url(self, id):
     return 'http://fa.ke/' + id

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -77,7 +77,6 @@ class FakeGrSource(FakeBase, gr_source.Source):
 
   __metaclass__ = FakeGrSourceMeta
 
-
   def user_url(self, id):
     return 'http://fa.ke/' + id
 


### PR DESCRIPTION
e.g. support for rel=feed for notes and one for articles. this fixes #423 