### PR TITLE
some basic CSS for webmention source permalinks

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -47,7 +47,22 @@ TEMPLATE = string.Template("""\
 <meta charset="utf-8">
 <title>$title</title>
 <style type="text/css">
-.u-uid { display: none; }
+body {
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+.u-uid {
+  display: none;
+}
+.u-photo {
+  max-width: 50px;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+}
+.e-content {
+  margin-top: 10px;
+  font-size: 1.3em;
+}
 </style>
 </head>
 $body

--- a/handlers.py
+++ b/handlers.py
@@ -55,8 +55,6 @@ body {
 }
 .u-photo {
   max-width: 50px;
-  -webkit-border-radius: 4px;
-  -moz-border-radius: 4px;
   border-radius: 4px;
 }
 .e-content {


### PR DESCRIPTION
I was hoping to get a little fancier with this, rearranging some of the HTML on the page to make the permalinks look a little better. But then I realized the HTML is generated by a different library and I don't really understand how it all works and don't have a good way to test it. Instead, this PR is some really simple CSS tweaks to make the permalinks look a little nicer. Basically forcing profile images to be small (some of them were the full browser width because Twitter doesn't resize images automatically), and I made the comment text larger so it stands out a little better.