### PR TITLE
infer facebook usernames from syndication URLs during PPD and OPD

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -66,6 +66,8 @@ class FacebookPage(models.Source):
   type = ndb.StringProperty(choices=('user', 'page'))
   # unique name used in fb URLs, e.g. facebook.com/[username]
   username = ndb.StringProperty()
+  # inferred from syndication URLs if username isn't available
+  inferred_username = ndb.StringProperty()
 
   @staticmethod
   def new(handler, auth_entity=None, **kwargs):
@@ -208,7 +210,7 @@ class FacebookPage(models.Source):
 
   def canonicalize_syndication_url(self, url):
     """Facebook-specific standardization of syndicated urls. Canonical form is
-    https://facebook.com/0123456789
+    https://www.facebook.com/0123456789
 
     Args:
       url: a string, the url of the syndicated content
@@ -221,13 +223,34 @@ class FacebookPage(models.Source):
     if ids:
       url = 'https://www.facebook.com/%s/posts/%s' % (self.key.id(), ids[0])
 
-    if self.username:
-      url = url.replace('facebook.com/%s/' % self.username,
+    username = self.username or self.inferred_username
+    if username:
+      url = url.replace('facebook.com/%s/' % username,
                         'facebook.com/%s/' % self.key.id())
 
     # facebook always uses https and www
     return re.sub('^https?://(www\.)?facebook.com/', 'https://www.facebook.com/',
                   url)
+
+  @ndb.transactional
+  def on_new_syndicated_post(self, syndpost):
+    """If this source has no username, try to infer one from a syndication URL.
+
+    Args:
+      syndpost: SyndicatedPost
+    """
+    url = syndpost.syndication
+    if self.username or not url:
+      return
+
+    # FB usernames only have letters, numbers, and periods:
+    # https://www.facebook.com/help/105399436216001
+    author_id = self.gr_source.base_object({'object': {'url': url}})\
+                              .get('author', {}).get('id')
+    if author_id and not util.is_int(author_id):
+      logging.info('Inferring username %s from syndication url %s', author_id, url)
+      self.inferred_username = author_id
+      self.put()
 
 
 class OAuthCallback(oauth_facebook.CallbackHandler, util.Handler):

--- a/facebook.py
+++ b/facebook.py
@@ -251,6 +251,7 @@ class FacebookPage(models.Source):
       logging.info('Inferring username %s from syndication url %s', author_id, url)
       self.inferred_username = author_id
       self.put()
+      syndpost.syndication = self.canonicalize_syndication_url(syndpost.syndication)
 
 
 class OAuthCallback(oauth_facebook.CallbackHandler, util.Handler):

--- a/models.py
+++ b/models.py
@@ -522,6 +522,14 @@ class Source(StringIdModel):
     """
     pass
 
+  def on_new_syndicated_post(self, syndpost):
+    """Called when a new SyndicatedPost is stored for this source.
+
+    Args:
+      syndpost: SyndicatedPost
+    """
+    pass
+
 
 class Webmentions(StringIdModel):
   """A bundle of links to send webmentions for.
@@ -739,6 +747,9 @@ class SyndicatedPost(ndb.Model):
   following rel=syndication links on the author's h-feed.
 
   See original_post_discovery.
+
+  When a new SyndicatedPost entity is created, its source's
+  on_new_syndicated_post() method is called.
   """
 
   # Turn off instance and memcache caching. See Response for details.
@@ -751,7 +762,7 @@ class SyndicatedPost(ndb.Model):
   updated = ndb.DateTimeProperty(auto_now=True)
 
   @classmethod
-  @ndb.transactional
+  @ndb.transactional(xg=True)
   def insert_original_blank(cls, source, original):
     """Insert a new original -> None relationship. Does a check-and-set to
     make sure no previous relationship exists for this original. If
@@ -766,7 +777,7 @@ class SyndicatedPost(ndb.Model):
     cls(parent=source.key, original=original, syndication=None).put()
 
   @classmethod
-  @ndb.transactional
+  @ndb.transactional(xg=True)
   def insert_syndication_blank(cls, source, syndication):
     """Insert a new syndication -> None relationship. Does a check-and-set
     to make sure no previous relationship exists for this
@@ -782,7 +793,7 @@ class SyndicatedPost(ndb.Model):
     cls(parent=source.key, original=None, syndication=syndication).put()
 
   @classmethod
-  @ndb.transactional
+  @ndb.transactional(xg=True)
   def insert(cls, source, syndication, original):
     """Insert a new (non-blank) syndication -> original relationship.
 
@@ -818,3 +829,6 @@ class SyndicatedPost(ndb.Model):
     r = cls(parent=source.key, original=original, syndication=syndication)
     r.put()
     return r
+
+  def _post_put_hook(self, future):
+    self.key.parent().get().on_new_syndicated_post(self)

--- a/models.py
+++ b/models.py
@@ -748,8 +748,8 @@ class SyndicatedPost(ndb.Model):
 
   See original_post_discovery.
 
-  When a new SyndicatedPost entity is created, its source's
-  on_new_syndicated_post() method is called.
+  When a SyndicatedPost entity is about to be stored, its source's
+  on_new_syndicated_post() method is called (before it's stored).
   """
 
   # Turn off instance and memcache caching. See Response for details.
@@ -830,5 +830,5 @@ class SyndicatedPost(ndb.Model):
     r.put()
     return r
 
-  def _post_put_hook(self, future):
+  def _pre_put_hook(self):
     self.key.parent().get().on_new_syndicated_post(self)

--- a/test/test_facebook.py
+++ b/test/test_facebook.py
@@ -312,9 +312,12 @@ class FacebookPageTest(testutil.ModelsTest):
     self.assertIsNone(fb.key.get().inferred_username)
 
     # should infer username
-    models.SyndicatedPost.insert(self.fb, original='http://fin.al',
-                                 syndication='http://facebook.com/fooey/posts/123')
+    syndpost = models.SyndicatedPost.insert(
+      self.fb, original='http://fin.al',
+      syndication='http://facebook.com/fooey/posts/123')
     self.assertEquals('fooey', fb.key.get().inferred_username)
+    self.assertEquals('https://www.facebook.com/212038/posts/123',
+                      syndpost.syndication)
 
 
 class FacebookPagePageTest(testutil.ModelsTest):

--- a/test/test_original_post_discovery.py
+++ b/test/test_original_post_discovery.py
@@ -1203,19 +1203,28 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
       self.assertTrue(sp)
       self.assertIsNone(sp.syndication)
 
-  def test_match_facebook_username_url(self):
+  def test_match_facebook_username(self):
     """Facebook URLs use username and user id interchangeably, and one
     does not redirect to the other. Make sure we can still find the
     relationship if author's publish syndication links using their
-    username
+    username.
     """
+    self._test_match_facebook_username({'id': '212038', 'username': 'snarfed.org'})
+
+  def test_match_facebook_inferred_username(self):
+    """Same test as above, but with inferred username."""
+    self._test_match_facebook_username({'id': '212038'},
+                                       inferred_username='snarfed.org')
+
+  def _test_match_facebook_username(self, user_obj, **source_params):
     auth_entity = oauth_facebook.FacebookAuth(
       id='my_string_id', auth_code='my_code', access_token_str='my_token',
-      user_json=json.dumps({'id': '212038', 'username': 'snarfed.org'}))
+      user_json=json.dumps(user_obj))
     auth_entity.put()
 
     source = FacebookPage.new(self.handler, auth_entity=auth_entity,
-                              domain_urls=['http://author'])
+                              domain_urls=['http://author'], **source_params)
+    source.put()
     # facebook activity comes to us with the numeric id
     self.activity['object']['url'] = 'http://facebook.com/212038/posts/314159'
 


### PR DESCRIPTION
fixes #447. needed because the facebook API no longer gives us usernames at all. :/