### PR TITLE
Add Location header to Publish response

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -320,6 +320,7 @@ class Handler(webmention.WebmentionHandler):
       self.entity.type_label = self.source.TYPE_LABELS.get(self.entity.type)
       self.response.headers['Content-Type'] = 'application/json'
       logging.info('Returning %s', json.dumps(self.entity.published, indent=2))
+      self.response.headers['Location'] = self.entity.published['url']
       return gr_source.creation_result(
         json.dumps(self.entity.published, indent=2))
 

--- a/templates/about.html
+++ b/templates/about.html
@@ -747,7 +747,8 @@ short link as the webmention's <code>source</code> parameter.
 responds. A <code>POST</code> to
 <code>http://brid.gy/publish/webmention</code> will return
 <code>200 OK</code> on success with a JSON response containing at least
-a <code>url</code> field that points to the silo object that it operated on. For
+a <code>url</code> field that points to the silo object that it operated on. The
+same URL is included in the <code>Location</code> HTTP header. For
 Twitter favorites and Facebook event RSVPs, this is the tweet, post, or event.
 If a new object was created, e.g. a Facebook post or Twitter tweet, @-reply, or
 retweet, there will also be an <code>id</code> field with the silo id of that
@@ -757,9 +758,13 @@ object.
 </p>
 <pre>POST <span class="keyword">source</span>=<span class="link">https://example.com/posts/123</span>
      &<span class="keyword">target</span>=<a href="https://www.brid.gy/publish/facebook">https://www.brid.gy/publish/facebook</a></pre>
-<p>will receive <code>200 OK</code> with this response:
+<p>will receive this response:
 </p>
-<pre>{
+<pre>HTTP/1.1 200 OK
+Content-Type: application/json
+Location: http://facebook.com/456_789
+
+{
   "<span class='keyword'>url</span>": "<span class='value'>http://facebook.com/456_789</span>",
   "<span class='keyword'>type</span>": "<span class='value'>post</span>",
   "<span class='keyword'>id</span>": "<span class='value'>456_789</span>"

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -94,7 +94,8 @@ class PublishTest(testutil.HandlerTest):
   def test_webmention_success(self):
     self.expect_requests_get('http://foo.com/bar', self.post_html % 'foo')
     self.mox.ReplayAll()
-    self.assert_success('foo - http://foo.com/bar', interactive=False)
+    resp = self.assert_success('foo - http://foo.com/bar', interactive=False)
+    self.assertEquals('http://fake/url', resp.headers['Location'])
     self._check_entity()
 
   def test_interactive_success(self):


### PR DESCRIPTION
https://indiewebcamp.com/syndication-brainstorming

Should probably also switch to returning `201 Created`... I hope existing clients check for `2xx` and not exactly `200`?