### PR TITLE
second half of big OPD refactoring for #51

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,5 @@
 application: brid-gy
-version: 4
+version: 5
 runtime: python27
 threadsafe: yes
 api_version: 1

--- a/handlers.py
+++ b/handlers.py
@@ -213,6 +213,8 @@ class ItemHandler(webapp2.RequestHandler):
                       if url not in existing]
 
 
+# Note that mention links are included in posts and comments, but not
+# likes, reposts, or rsvps. Matches logic in poll() (step 4) in tasks.py!
 class PostHandler(ItemHandler):
   def get_item(self, id):
     post = self.source.get_post(id)

--- a/original_post_discovery.py
+++ b/original_post_discovery.py
@@ -38,6 +38,8 @@ from google.appengine.api.datastore import MAX_ALLOWABLE_QUERIES
 from bs4 import BeautifulSoup
 from models import SyndicatedPost
 
+from google.appengine.api import memcache
+
 # alias allows unit tests to mock the function
 now_fn = datetime.datetime.now
 
@@ -57,10 +59,23 @@ def discover(source, activity, fetch_hfeed=True):
     activity: activity dict
     fetch_hfeed: boolean
 
-  Return:
-    the activity, updated with original post urls if any are found
+  Returns: ([string original post URLs], [string mention URLs]) tuple
   """
-  gr_source.Source.original_post_discovery(activity, domains=source.domains)
+  originals, mentions = gr_source.Source.original_post_discovery(
+    activity, domains=source.domains, cache=memcache,
+    headers=util.USER_AGENT_HEADER)
+
+  def resolve(urls):
+    resolved = set()
+    for url in urls:
+      url, _, send = util.get_webmention_target(
+        util.replace_test_domains_with_localhost(url))
+      if send:
+        resolved.add(url)
+    return resolved
+
+  originals = resolve(originals)
+  mentions = resolve(mentions)
 
   # TODO possible optimization: if we've discovered a backlink to a
   # post on the author's domain (i.e., it included a link or
@@ -70,21 +85,22 @@ def discover(source, activity, fetch_hfeed=True):
 
   if not source.get_author_urls():
     logging.debug('no author url(s), cannot find h-feed')
-    return activity
+    return originals, mentions
 
-  if not syndication_url:
+  if syndication_url:
+    # use the canonical syndication url on both sides, so that we have
+    # the best chance of finding a match. Some silos allow several
+    # different permalink formats to point to the same place (e.g.,
+    # facebook user id instead of user name)
+    syndication_url = source.canonicalize_syndication_url(
+      util.follow_redirects(syndication_url).url)
+    originals.update(_posse_post_discovery(source, activity, syndication_url,
+                                           fetch_hfeed))
+  else:
     logging.debug('no syndication url, cannot process h-entries %s',
                   syndication_url)
-    return activity
 
-  # use the canonical syndication url on both sides, so that we have
-  # the best chance of finding a match. Some silos allow several
-  # different permalink formats to point to the same place (e.g.,
-  # facebook user id instead of user name)
-  syndication_url = source.canonicalize_syndication_url(
-    util.follow_redirects(syndication_url).url)
-
-  return _posse_post_discovery(source, activity, syndication_url, fetch_hfeed)
+  return originals, mentions
 
 
 def refetch(source):
@@ -119,7 +135,7 @@ def _posse_post_discovery(source, activity, syndication_url, fetch_hfeed):
                  relationship.
 
   Return:
-    the activity, updated with original post urls if any are found
+    sequence of string original post urls, possibly empty
   """
   logging.info('starting posse post discovery with syndicated %s', syndication_url)
   relationships = SyndicatedPost.query(
@@ -129,14 +145,12 @@ def _posse_post_discovery(source, activity, syndication_url, fetch_hfeed):
     # a syndicated post we haven't seen before! fetch the author's URLs to see
     # if we can find it.
     #
-    # Use source.domain_urls for now; it seems more reliable than the
-    # activity.actor.url (which depends on getting the right data back from
-    # various APIs). Consider using the actor's url, with domain_urls as the
+    # TODO: Consider using the actor's url, with get_author_urls() as the
     # fallback in the future to support content from non-Bridgy users.
     results = {}
     for url in source.get_author_urls():
       results.update(_process_author(source, url))
-    relationships = results.get(syndication_url)
+    relationships = results.get(syndication_url, [])
 
   if not relationships:
     # No relationships were found. Remember that we've seen this
@@ -145,18 +159,12 @@ def _posse_post_discovery(source, activity, syndication_url, fetch_hfeed):
                   syndication_url)
     if fetch_hfeed:
       SyndicatedPost.insert_syndication_blank(source, syndication_url)
-    return activity
 
-  logging.debug('posse post discovery found relationship(s) %s -> %s',
-                syndication_url,
-                '; '.join(unicode(r.original) for r in relationships))
-
-  obj = activity.get('object') or activity
-  uds = obj.setdefault('upstreamDuplicates', [])
-  uds.extend(r.original for r in relationships
-             if r.original and r.original not in uds)
-
-  return activity
+  originals = [r.original for r in relationships if r.original]
+  if originals:
+    logging.debug('posse post discovery found relationship(s) %s -> %s',
+                  syndication_url, originals)
+  return originals
 
 
 def _process_author(source, author_url, refetch=False, store_blanks=True):

--- a/original_post_discovery.py
+++ b/original_post_discovery.py
@@ -68,8 +68,7 @@ def discover(source, activity, fetch_hfeed=True):
   def resolve(urls):
     resolved = set()
     for url in urls:
-      url, _, send = util.get_webmention_target(
-        util.replace_test_domains_with_localhost(url))
+      url, _, send = util.get_webmention_target(url)
       if send:
         resolved.add(url)
     return resolved
@@ -77,9 +76,9 @@ def discover(source, activity, fetch_hfeed=True):
   originals = resolve(originals)
   mentions = resolve(mentions)
 
-  # TODO possible optimization: if we've discovered a backlink to a
-  # post on the author's domain (i.e., it included a link or
-  # citation), then skip the rest of this.
+  # TODO possible optimization: if we've discovered a backlink to a post on the
+  # author's domain (i.e., it included a link or citation), then skip the rest
+  # of this.
   obj = activity.get('object') or activity
   syndication_url = obj.get('url')
 

--- a/tasks.py
+++ b/tasks.py
@@ -236,8 +236,8 @@ class Poll(webapp2.RequestHandler):
         # discovered webmention targets inside its object.
         targets = activity.get('targets')
         if targets is None:
-          targets = original_post_discovery.discover(source, activity)
-          activity['targets'] = targets
+          originals, mentions = original_post_discovery.discover(source, activity)
+          targets = activity['targets'] = originals | mentions
           source_updates['last_syndication_url'] = source.last_syndication_url
         logging.info('%s has %d original post URL(s): %s', activity.get('url'),
                      len(targets), ' '.join(targets))
@@ -407,9 +407,6 @@ class SendWebmentions(webapp2.RequestHandler):
       # or streaming add.
       url, domain, ok = util.get_webmention_target(orig_url)
       if ok:
-        # When debugging locally, redirect our own webmentions to localhost
-        if appengine_config.DEBUG and domain in util.LOCALHOST_TEST_DOMAINS:
-          url = url.replace(domain, 'localhost')
         if len(url) <= _MAX_STRING_LENGTH:
           unsent.add(url)
         else:

--- a/tasks.py
+++ b/tasks.py
@@ -236,7 +236,8 @@ class Poll(webapp2.RequestHandler):
         # discovered webmention targets inside its object.
         targets = activity.get('targets')
         if targets is None:
-          originals, mentions = original_post_discovery.discover(source, activity)
+          originals, mentions = original_post_discovery.discover(
+            source, activity, include_redirect_sources=False)
           targets = activity['targets'] = originals | mentions
           source_updates['last_syndication_url'] = source.last_syndication_url
         logging.info('%s has %d original post URL(s): %s', activity.get('url'),

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -64,10 +64,7 @@ class HandlersTest(testutil.HandlerTest):
   <div class="e-content p-name">
 
   asdf http://other/link qwert
-  <p>
-  <a class="link" href="http://other/link">
-  </a>
-  </p>
+  <a class="u-mention" href="http://other/link"></a>
   </div>
 
 </article>
@@ -84,10 +81,8 @@ class HandlersTest(testutil.HandlerTest):
           'url': ['http://fa.ke/000', 'http://or.ig/post'],
           'content': [{ 'html': """\
 asdf http://other/link qwert
-<p>
-<a class="link" href="http://other/link">
-</a>
-</p>""",
+<a class="u-mention" href="http://other/link"></a>
+""",
                         'value': 'asdf http://other/link qwert',
                         }],
           'author': [{
@@ -329,10 +324,10 @@ asdf http://other/link qwert
         'inReplyTo': [{'url': 'http://fa.ke/000'}],
         })
 
-    self.expect_requests_head('http://or.ig/post',
-                              redirected_url='http://or.ig/post/redirect')
-    self.expect_requests_head('http://other/link',
-                              redirected_url='http://other/link/redirect')
+    self.expect_requests_head(
+      'http://or.ig/post', redirected_url='http://or.ig/post/redirect').InAnyOrder()
+    self.expect_requests_head(
+      'http://other/link', redirected_url='http://other/link/redirect').InAnyOrder()
     self.mox.ReplayAll()
 
     self.check_response('/comment/fake/%s/000/111', """\
@@ -347,8 +342,8 @@ asdf http://other/link qwert
   </div>
 
   <a class="u-in-reply-to" href="http://fa.ke/000"></a>
-  <a class="u-in-reply-to" href="http://or.ig/post"></a>
   <a class="u-in-reply-to" href="http://or.ig/post/redirect"></a>
+  <a class="u-in-reply-to" href="http://or.ig/post"></a>
 
 </article>
 """)
@@ -400,20 +395,16 @@ asdf http://other/link qwert
 
   <div class="e-content p-name">
 
-  <a class="u-mention" href="http://all"></a>
   <a class="u-mention" href="http://upstream/only"></a>
-  <a class="u-mention" href="http://upstream"></a>
   <a class="u-mention" href="http://mention/only"></a>
+  <a class="u-mention" href="https://reply"></a>
+  <a class="u-mention" href="https://upstream"></a>
+  <a class="u-mention" href="http://all"></a>
   </div>
 
-  <a class="u-in-reply-to" href="https://reply"></a>
   <a class="u-in-reply-to" href="https://reply/only"></a>
-  <a class="u-in-reply-to" href="https://all"></a>
-  <a class="u-in-reply-to" href="https://upstream"></a>
-  <a class="u-in-reply-to" href="http://all"></a>
-  <a class="u-in-reply-to" href="http://upstream/only"></a>
-  <a class="u-in-reply-to" href="http://upstream"></a>
   <a class="u-in-reply-to" href="http://reply"></a>
+  <a class="u-in-reply-to" href="https://all"></a>
 
 </article>
 """)

--- a/test/test_original_post_discovery.py
+++ b/test/test_original_post_discovery.py
@@ -34,9 +34,10 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
       'content': 'content without links',
       })
 
-  def assert_discover(self, expected_originals, expected_mentions=[]):
+  def assert_discover(self, expected_originals, expected_mentions=[],
+                      source=None):
     self.assertEquals((set(expected_originals), set(expected_mentions)),
-                      discover(self.source, self.activity))
+                      discover(source or self.source, self.activity))
 
 
   def assert_syndicated_posts(self, *expected):
@@ -1082,9 +1083,9 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
       user_json=json.dumps(user_obj))
     auth_entity.put()
 
-    source = FacebookPage.new(self.handler, auth_entity=auth_entity,
-                              domain_urls=['http://author'], **source_params)
-    source.put()
+    fb = FacebookPage.new(self.handler, auth_entity=auth_entity,
+                          domain_urls=['http://author'], **source_params)
+    fb.put()
     # facebook activity comes to us with the numeric id
     self.activity['object']['url'] = 'http://facebook.com/212038/posts/314159'
 
@@ -1103,4 +1104,4 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     </html>""")
 
     self.mox.ReplayAll()
-    self.assert_discover(['http://author/post/permalink'])
+    self.assert_discover(['http://author/post/permalink'], source=fb)

--- a/test/test_original_post_discovery.py
+++ b/test/test_original_post_discovery.py
@@ -13,7 +13,7 @@ from requests.exceptions import HTTPError
 from facebook import FacebookPage
 from models import SyndicatedPost
 import util
-import original_post_discovery
+from original_post_discovery import discover, refetch
 import tasks
 import test_facebook
 import testutil
@@ -26,12 +26,18 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     self.source = self.sources[0]
     self.source.domain_urls = ['http://author']
     self.source.domains = ['author']
+    self.source.put()
 
     self.activity = self.activities[0]
     self.activity['object'].update({
       'url': 'https://fa.ke/post/url',  # silo domain is fa.ke
       'content': 'content without links',
       })
+
+  def assert_discover(self, expected_originals, expected_mentions=[]):
+    self.assertEquals((set(expected_originals), set(expected_mentions)),
+                      discover(self.source, self.activity))
+
 
   def assert_syndicated_posts(self, *expected):
     self.assertItemsEqual(expected,
@@ -42,8 +48,6 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     """Test that original post discovery does the reverse lookup to scan
     author's h-feed for rel=syndication links
     """
-    self.activity['object']['upstreamDuplicates'] = ['existing uD']
-
     self.expect_requests_get('http://author', """
     <html class="h-feed">
       <div class="h-entry">
@@ -60,29 +64,15 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     </div>""")
 
     self.mox.ReplayAll()
-    logging.debug('Original post discovery %s -> %s', self.source, self.activity)
-    original_post_discovery.discover(self.source, self.activity)
-
-    # upstreamDuplicates = 1 original + 1 discovered
-    self.assertEquals(['existing uD', 'http://author/post/permalink'],
-                      self.activity['object']['upstreamDuplicates'])
-
-    origurls = [r.original for r in SyndicatedPost.query(ancestor=self.source.key)]
-    self.assertEquals([u'http://author/post/permalink'], origurls)
-
-    # for now only syndicated posts belonging to this source are stored
-    syndurls = list(r.syndication for r
-                    in SyndicatedPost.query(ancestor=self.source.key))
-
-    self.assertEquals([u'https://fa.ke/post/url'], syndurls)
+    self.assert_discover(['http://author/post/permalink'])
+    self.assert_syndicated_posts(('http://author/post/permalink',
+                                  'https://fa.ke/post/url'))
 
   def test_syndication_url_in_hfeed(self):
     """Like test_single_post, but because the syndication URL is given in
     the h-feed we skip fetching the permalink. New behavior as of
     2014-11-08
     """
-    self.activity['object']['upstreamDuplicates'] = ['existing uD']
-
     # silo domain is fa.ke
     self.expect_requests_get('http://author', """
     <html class="h-feed">
@@ -93,21 +83,9 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     </html>""")
 
     self.mox.ReplayAll()
-    logging.debug('Original post discovery %s -> %s', self.source, self.activity)
-    original_post_discovery.discover(self.source, self.activity)
-
-    # upstreamDuplicates = 1 original + 1 discovered
-    self.assertEquals(['existing uD', 'http://author/post/permalink'],
-                      self.activity['object']['upstreamDuplicates'])
-
-    origurls = [r.original for r in SyndicatedPost.query(ancestor=self.source.key)]
-    self.assertEquals([u'http://author/post/permalink'], origurls)
-
-    # for now only syndicated posts belonging to this source are stored
-    syndurls = list(r.syndication for r
-                    in SyndicatedPost.query(ancestor=self.source.key))
-
-    self.assertEquals([u'https://fa.ke/post/url'], syndurls)
+    self.assert_discover(['http://author/post/permalink'])
+    self.assert_syndicated_posts(('http://author/post/permalink',
+                                  'https://fa.ke/post/url'))
 
   def test_additional_requests_do_not_require_rework(self):
     """Test that original post discovery fetches and stores all entries up
@@ -115,11 +93,11 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     every new post. Test that original post discovery does the reverse
     lookup to scan author's h-feed for rel=syndication links
     """
-    for idx, activity in enumerate(self.activities):
-        activity['object'].update({
-          'content': 'post content without backlinks',
-          'url': 'https://fa.ke/post/url%d' % (idx + 1),
-        })
+    for i, activity in enumerate(self.activities):
+      activity['object'].update({
+        'content': 'post content without backlinks',
+        'url': 'https://fa.ke/post/url%d' % (i + 1),
+      })
 
     author_feed = u"""
     <html class="h-feed">
@@ -165,62 +143,29 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     self.mox.ReplayAll()
 
     # first activity should trigger all the lookups and storage
-    original_post_discovery.discover(self.source, self.activities[0])
-
-    self.assertEquals(['http://author/post/permalink1'],
-                      self.activities[0]['object']['upstreamDuplicates'])
-
-    # make sure things are where we want them
-    rs = SyndicatedPost.query(
-      SyndicatedPost.original == 'http://author/post/permalink1',
-      ancestor=self.source.key).fetch()
-    self.assertEquals('https://fa.ke/post/url1', rs[0].syndication)
-    rs = SyndicatedPost.query(
-      SyndicatedPost.syndication == 'https://fa.ke/post/url1',
-      ancestor=self.source.key).fetch()
-    self.assertEquals('http://author/post/permalink1', rs[0].original)
-
-    rs = SyndicatedPost.query(
-      SyndicatedPost.original == u'http://author/post/perma✁2',
-      ancestor=self.source.key).fetch()
-    self.assertEquals('https://fa.ke/post/url2', rs[0].syndication)
-    rs = SyndicatedPost.query(
-      SyndicatedPost.syndication == 'https://fa.ke/post/url2',
-      ancestor=self.source.key).fetch()
-    self.assertEquals(u'http://author/post/perma✁2', rs[0].original)
-
-    rs = SyndicatedPost.query(
-      SyndicatedPost.original == 'http://author/post/permalink3',
-      ancestor=self.source.key).fetch()
-    self.assertEquals(None, rs[0].syndication)
+    self.assert_discover(['http://author/post/permalink1'])
+    syndposts = [('http://author/post/permalink1', 'https://fa.ke/post/url1'),
+                 (u'http://author/post/perma✁2', 'https://fa.ke/post/url2'),
+                 ('http://author/post/permalink3', None)]
+    self.assert_syndicated_posts(*syndposts)
 
     # second lookup should require no additional HTTP requests.
     # the second syndicated post should be linked up to the second permalink.
-    original_post_discovery.discover(self.source, self.activities[1])
-    self.assertEquals([u'http://author/post/perma✁2'],
-                      self.activities[1]['object']['upstreamDuplicates'])
+    self.assertEquals((set([u'http://author/post/perma✁2']), set()),
+                      discover(self.source, self.activities[1]))
 
-    # third activity lookup.
-    # since we didn't find a back-link for the third syndicated post,
-    # it should fetch the author's feed again, but seeing no new
-    # posts, it should not follow any of the permalinks
+    # third activity lookup. since we didn't find a back-link for the third
+    # syndicated post, it should fetch the author's feed again, but seeing no
+    # new posts, it should not follow any of the permalinks.
+    self.assertEquals((set(), set()), discover(self.source, self.activities[2]))
 
-    original_post_discovery.discover(self.source, self.activities[2])
-    # should have found no new syndication link
-    self.assertFalse(self.activities[2]['object'].get('upstreamDuplicates'))
+    # should have saved a blank to prevent subsequent checks of this syndicated
+    # post from fetching the h-feed again
+    syndposts.append((None, 'https://fa.ke/post/url3'))
+    self.assert_syndicated_posts(*syndposts)
 
-    # should have saved a blank to prevent subsequent checks of this
-    # syndicated post from fetching the h-feed again
-    rs = SyndicatedPost.query(
-      SyndicatedPost.syndication == 'https://fa.ke/post/url3',
-      ancestor=self.source.key).fetch()
-    self.assertIsNone(rs[0].original)
-
-    # confirm that we do not fetch the h-feed again for the same
-    # syndicated post
-    original_post_discovery.discover(self.source, self.activities[2])
-    # should be no new syndication link
-    self.assertFalse(self.activities[2]['object'].get('upstreamDuplicates'))
+    # confirm that we do not fetch the h-feed again for the same syndicated post
+    self.assertEquals((set(), set()), discover(self.source, self.activities[2]))
 
   def test_no_duplicate_links(self):
     """Make sure that a link found by both original-post-discovery and
@@ -242,11 +187,7 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     </div>""" % (original, 'https://fa.ke/post/url'))
 
     self.mox.ReplayAll()
-    logging.debug('Original post discovery %s -> %s', self.source, self.activity)
-
-    wmtargets = tasks.get_webmention_targets(self.source, self.activity)
-    self.assertEquals([original], self.activity['object']['upstreamDuplicates'])
-    self.assertEquals([original], wmtargets)
+    self.assert_discover([original])
 
   def test_strip_www_when_comparing_domains(self):
     """We should ignore leading www when comparing syndicated URL domains."""
@@ -262,11 +203,9 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     <div class="h-entry">
       <a class="u-syndication" href="http://www.fa.ke/post/url"></a>
     </div>""")
-    self.mox.ReplayAll()
 
-    original_post_discovery.discover(self.source, self.activity)
-    self.assertEquals(['http://author/post/url'],
-                      self.activity['object']['upstreamDuplicates'])
+    self.mox.ReplayAll()
+    self.assert_discover(['http://author/post/url'])
 
   def test_rel_feed_link(self):
     """Check that we follow the rel=feed link when looking for the
@@ -289,8 +228,7 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     </html>""")
 
     self.mox.ReplayAll()
-    logging.debug('Original post discovery %s -> %s', self.source, self.activity)
-    original_post_discovery.discover(self.source, self.activity)
+    discover(self.source, self.activity)
 
   def test_rel_feed_anchor(self):
     """Check that we follow the rel=feed when it's in an <a> tag instead of <link>
@@ -314,8 +252,7 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     </html>""")
 
     self.mox.ReplayAll()
-    logging.debug('Original post discovery %s -> %s', self.source, self.activity)
-    original_post_discovery.discover(self.source, self.activity)
+    discover(self.source, self.activity)
 
   def test_no_h_entries(self):
     """Make sure nothing bad happens when fetching a feed without h-entries.
@@ -326,8 +263,7 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     </html>""")
 
     self.mox.ReplayAll()
-    logging.debug('Original post discovery %s -> %s', self.source, self.activity)
-    original_post_discovery.discover(self.source, self.activity)
+    self.assert_discover([])
     self.assert_syndicated_posts((None, 'https://fa.ke/post/url'))
 
   def test_existing_syndicated_posts(self):
@@ -342,11 +278,8 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     SyndicatedPost(parent=self.source.key, original=original_url,
                    syndication=syndication_url).put()
 
-    logging.debug('Original post discovery %s -> %s', self.source, self.activity)
-    original_post_discovery.discover(self.source, self.activity)
-
     # should append the author note url, with no addt'l requests
-    self.assertEquals([original_url], self.activity['object']['upstreamDuplicates'])
+    self.assert_discover([original_url])
 
   def test_invalid_webmention_target(self):
     """Confirm that no additional requests are made if the author url is
@@ -356,10 +289,7 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     endpoint or microformats.
     """
     self.source.domain_urls = ['http://amazon.com']
-
-    logging.debug('Original post discovery %s -> %s', self.source, self.activity)
-    original_post_discovery.discover(self.source, self.activity)
-
+    discover(self.source, self.activity)
     # nothing attempted, but we should have saved a placeholder to prevent us
     # from trying again
     self.assert_syndicated_posts((None, 'https://fa.ke/post/url'))
@@ -374,7 +304,7 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
       self.expect_requests_get('http://author', status_code=404)
 
     self.mox.ReplayAll()
-    original_post_discovery.discover(self.source, self.activity)
+    discover(self.source, self.activity)
 
     # nothing attempted, but we should have saved a placeholder to prevent us
     # from trying again
@@ -415,15 +345,14 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
   def test_discover_multiple_domain_urls(self):
     """We should fetch and process all of a source's URLs."""
     self._expect_multiple_domain_url_fetches()
-    result = original_post_discovery.discover(self.source, self.activity)
-    self.assert_equals(['http://author1/A'], result['object']['upstreamDuplicates'])
+    self.assert_discover(['http://author1/A'])
     self.assert_syndicated_posts(('http://author1/A', 'https://fa.ke/A'),
                                  ('http://author3/B', 'https://fa.ke/B'))
 
   def test_refetch_multiple_domain_urls(self):
     """We should refetch all of a source's URLs."""
     self._expect_multiple_domain_url_fetches()
-    result = original_post_discovery.refetch(self.source)
+    result = refetch(self.source)
     self.assert_equals(['https://fa.ke/A' ,'https://fa.ke/B'], result.keys())
     self.assert_syndicated_posts(('http://author1/A', 'https://fa.ke/A'),
                                  ('http://author3/B', 'https://fa.ke/B'))
@@ -454,8 +383,7 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     self.expect_requests_get('http://author/recover_and_fetch_this.html', 'ok')
 
     self.mox.ReplayAll()
-    logging.debug('Original post discovery %s -> %s', self.source, self.activity)
-    original_post_discovery.discover(self.source, self.activity)
+    discover(self.source, self.activity)
 
   def _test_failed_post_permalink_fetch(self, raise_exception):
     """Make sure something reasonable happens when we're unable to fetch
@@ -475,8 +403,7 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
       self.expect_requests_get('http://author/nonexistent.html', status_code=410)
 
     self.mox.ReplayAll()
-    original_post_discovery.discover(self.source, self.activity)
-
+    discover(self.source, self.activity)
     # we should have saved placeholders to prevent us from trying the
     # syndication url or permalink again
     self.assert_syndicated_posts(('http://author/nonexistent.html', None),
@@ -499,7 +426,7 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     a url at all.
     """
     self.source.domain_urls = []
-    original_post_discovery.discover(self.source, self.activity)
+    discover(self.source, self.activity)
     # nothing attempted, and no SyndicatedPost saved
     self.assertFalse(SyndicatedPost.query(ancestor=self.source.key).get())
 
@@ -516,13 +443,12 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     """)
 
     self.mox.ReplayAll()
-    original_post_discovery.discover(self.source, self.activity)
+    discover(self.source, self.activity)
 
   def test_feed_head_request_failed(self):
     """Confirm that we don't follow rel=feeds explicitly marked as
     application/xml.
     """
-    self.mox.StubOutWithMock(requests, 'head', use_mock_anything=True)
     self.expect_requests_get('http://author', """
     <html>
       <head>
@@ -551,13 +477,12 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     self.expect_requests_get('http://author/permalink', '<html></html>')
 
     self.mox.ReplayAll()
-    original_post_discovery.discover(self.source, self.activity)
+    discover(self.source, self.activity)
 
   def test_feed_type_unknown(self):
     """Confirm that we look for an h-feed with type=text/html even when
     the type is not given in <link>, and keep looking until we find one.
     """
-    self.mox.StubOutWithMock(requests, 'head', use_mock_anything=True)
     self.expect_requests_get('http://author', """
     <html>
       <head>
@@ -603,7 +528,7 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     </html>""")
 
     self.mox.ReplayAll()
-    original_post_discovery.discover(self.source, self.activity)
+    discover(self.source, self.activity)
 
   # TODO: activity with existing responses, make sure they're merged right
 
@@ -649,21 +574,11 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     </html>""").InAnyOrder('permalink')
 
     self.mox.ReplayAll()
-    original_post_discovery.discover(self.source, self.activity)
-
-    note_rels = SyndicatedPost.query(
-      SyndicatedPost.original == 'http://author/note-permalink',
-      ancestor=self.source.key).fetch()
-
-    self.assertEqual(1, len(note_rels))
-    self.assertEqual('https://fa.ke/note', note_rels[0].syndication)
-
-    article_rels = SyndicatedPost.query(
-      SyndicatedPost.original == 'http://author/article-permalink',
-      ancestor=self.source.key).fetch()
-
-    self.assertEqual(1, len(article_rels))
-    self.assertEqual('https://fa.ke/article', article_rels[0].syndication)
+    discover(self.source, self.activity)
+    self.assert_syndicated_posts(
+      ('http://author/note-permalink', 'https://fa.ke/note'),
+      ('http://author/article-permalink', 'https://fa.ke/article'),
+      (None, u'https://fa.ke/post/url'))
 
   def test_avoid_author_page_with_bad_content_type(self):
     """Confirm that we check the author page's content type before
@@ -677,7 +592,7 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
 
     # give up
     self.mox.ReplayAll()
-    original_post_discovery.discover(self.source, self.activity)
+    discover(self.source, self.activity)
 
   def test_avoid_permalink_with_bad_content_type(self):
     """Confirm that we don't follow u-url's that lead to anything that
@@ -704,15 +619,33 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
 
     # call to requests.get for permalink should be skipped
     self.mox.ReplayAll()
-    original_post_discovery.discover(self.source, self.activity)
+    discover(self.source, self.activity)
 
   def test_do_not_fetch_hfeed(self):
     """Confirms behavior of discover() when fetch_hfeed=False.
     Discovery should only check the database for previously discovered matches.
     It should not make any GET requests
     """
-    original_post_discovery.discover(self.source, self.activity, fetch_hfeed=False)
+    discover(self.source, self.activity, fetch_hfeed=False)
     self.assertFalse(SyndicatedPost.query(ancestor=self.source.key).get())
+
+  def test_source_domains(self):
+    """Only links to the user's own domains should end up in upstreamDuplicates.
+    """
+    self.expect_requests_get('http://author', '')
+    self.mox.ReplayAll()
+
+    self.activity['object']['content'] = 'x http://author/post y https://mention z'
+    self.assert_discover(['http://author/post'], ['https://mention'])
+
+    self.activity['object']['content'] = 'a https://mention b'
+    self.assert_discover([], ['https://mention'])
+
+    # if we don't know the user's domains, we should allow anything
+    self.source.domain_urls = self.source.domains = []
+    self.source.put()
+
+    self.assert_discover(['https://mention'])
 
   def test_refetch_hfeed(self):
     """refetch should grab resources again, even if they were previously
@@ -760,29 +693,11 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
       </html>""").InAnyOrder()
 
     self.mox.ReplayAll()
-    original_post_discovery.refetch(self.source)
-
-    relationships1 = SyndicatedPost.query(
-      SyndicatedPost.original == 'http://author/permalink1',
-      ancestor=self.source.key).fetch()
-
-    self.assertTrue(relationships1)
-    self.assertEquals('https://fa.ke/post/url1', relationships1[0].syndication)
-
-    relationships2 = SyndicatedPost.query(
-      SyndicatedPost.original == 'http://author/permalink2',
-      ancestor=self.source.key).fetch()
-
-    # this shouldn't have changed
-    self.assertTrue(relationships2)
-    self.assertEquals('https://fa.ke/post/url2', relationships2[0].syndication)
-
-    relationships3 = SyndicatedPost.query(
-      SyndicatedPost.original == 'http://author/permalink3',
-      ancestor=self.source.key).fetch()
-
-    self.assertTrue(relationships3)
-    self.assertIsNone(relationships3[0].syndication)
+    refetch(self.source)
+    self.assert_syndicated_posts(
+      ('http://author/permalink1', 'https://fa.ke/post/url1'),
+      ('http://author/permalink2', 'https://fa.ke/post/url2'),
+      ('http://author/permalink3', None))
 
   def test_refetch_multiple_responses_same_activity(self):
     """Ensure that refetching a post that has several replies does not
@@ -815,23 +730,10 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     self.mox.ReplayAll()
 
     for activity in self.activities:
-      original_post_discovery.discover(self.source, activity)
-
-    original_post_discovery.refetch(self.source)
-
-    rels_by_original = list(
-      SyndicatedPost.query(SyndicatedPost.original == 'http://author/post/permalink',
-                           ancestor=self.source.key).fetch())
-
-    self.assertEquals(1, len(rels_by_original))
-    self.assertIsNone(rels_by_original[0].syndication)
-
-    rels_by_syndication = list(
-      SyndicatedPost.query(SyndicatedPost.syndication == 'https://fa.ke/post/url',
-                           ancestor=self.source.key).fetch())
-
-    self.assertEquals(1, len(rels_by_syndication))
-    self.assertIsNone(rels_by_syndication[0].original)
+      discover(self.source, activity)
+    refetch(self.source)
+    self.assert_syndicated_posts(('http://author/post/permalink', None),
+                                 (None, 'https://fa.ke/post/url'))
 
   def test_multiple_refetches(self):
     """Ensure that multiple refetches of the same post (with and without
@@ -869,28 +771,13 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     self.expect_requests_get('http://author/permalink', syndicated)
 
     self.mox.ReplayAll()
-    original_post_discovery.discover(self.source, self.activities[0])
-    original_post_discovery.refetch(self.source)
+    discover(self.source, self.activities[0])
+    refetch(self.source)
+    self.assert_syndicated_posts(('http://author/permalink', None),
+                                 (None, u'https://fa.ke/post/url'))
 
-    relations = list(
-      SyndicatedPost.query(
-        SyndicatedPost.original == 'http://author/permalink',
-        ancestor=self.source.key).fetch())
-
-    self.assertEquals(1, len(relations))
-    self.assertEquals('http://author/permalink', relations[0].original)
-    self.assertIsNone(relations[0].syndication)
-
-    original_post_discovery.refetch(self.source)
-
-    relations = list(
-      SyndicatedPost.query(
-        SyndicatedPost.original == 'http://author/permalink',
-        ancestor=self.source.key).fetch())
-
-    self.assertEquals(1, len(relations))
-    self.assertEquals('http://author/permalink', relations[0].original)
-    self.assertEquals('https://fa.ke/post/url', relations[0].syndication)
+    refetch(self.source)
+    self.assert_syndicated_posts(('http://author/permalink', 'https://fa.ke/post/url'))
 
   def test_refetch_two_permalinks_same_syndication(self):
     """
@@ -925,17 +812,13 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
       self.expect_requests_get(permalink, content)
 
     self.mox.ReplayAll()
-    activity = original_post_discovery.discover(self.source, self.activities[0])
-    self.assertItemsEqual(['http://author/post1', 'http://author/post2'],
-                          activity['object'].get('upstreamDuplicates'))
-
+    self.assert_discover(['http://author/post1', 'http://author/post2'])
     self.assert_syndicated_posts(('http://author/post1', 'https://fa.ke/post/url'),
                                  ('http://author/post2', 'https://fa.ke/post/url'))
 
     # discover should have already handled all relationships, refetch should
     # not find anything
-    refetch_result = original_post_discovery.refetch(self.source)
-    self.assertFalse(refetch_result)
+    self.assertFalse(refetch(self.source))
 
   def test_refetch_permalink_with_two_syndications(self):
     """Test one permalink with two syndicated posts. Make sure that
@@ -963,24 +846,16 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
 
     # refetch
     self.expect_requests_get('http://author', hfeed)
-    # refetch grabs posts that it's seen before in case there have
-    # been updates
+    # refetch grabs posts that it's seen before in case there have been updates
     self.expect_requests_get('http://author/permalink', hentry)
 
     self.mox.ReplayAll()
-
-    original_post_discovery.discover(self.source, self.activities[0])
-    relations = SyndicatedPost.query(
-      SyndicatedPost.original == 'http://author/permalink',
-      ancestor=self.source.key).fetch()
-    self.assertItemsEqual(
-      [('http://author/permalink', 'https://fa.ke/post/url1'),
-       ('http://author/permalink', 'https://fa.ke/post/url3'),
-       ('http://author/permalink', 'https://fa.ke/post/url5')],
-      [(r.original, r.syndication) for r in relations])
-
-    results = original_post_discovery.refetch(self.source)
-    self.assertFalse(results)
+    discover(self.source, self.activities[0])
+    self.assert_syndicated_posts(
+      ('http://author/permalink', 'https://fa.ke/post/url1'),
+      ('http://author/permalink', 'https://fa.ke/post/url3'),
+      ('http://author/permalink', 'https://fa.ke/post/url5'))
+    self.assertFalse(refetch(self.source))
 
   def test_refetch_with_updated_permalink(self):
     """Permalinks can change (e.g., if a stub is added or modified).
@@ -1030,15 +905,12 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     </html>""")
 
     self.mox.ReplayAll()
-    activity = original_post_discovery.discover(self.source, self.activities[0])
-
     # modified activity should have /2014/08/09 as an upstreamDuplicate now
-    self.assertEquals(['http://author/2014/08/09'],
-                      activity['object']['upstreamDuplicates'])
+    self.assert_discover(['http://author/2014/08/09'])
 
     # refetch should find the updated original url -> syndication url.
     # it should *not* find the previously discovered relationship.
-    first_results = original_post_discovery.refetch(self.source)
+    first_results = refetch(self.source)
     self.assertEquals(1, len(first_results))
     new_relations = first_results.get('https://fa.ke/post/url')
     self.assertEquals(1, len(new_relations))
@@ -1048,8 +920,7 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
 
     # second refetch should find nothing because nothing has changed
     # since the previous refetch.
-    second_results = original_post_discovery.refetch(self.source)
-    self.assertFalse(second_results)
+    self.assertFalse(refetch(self.source))
 
   def test_refetch_changed_syndication(self):
     """Update syndication links that have changed since our last fetch."""
@@ -1065,9 +936,9 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     </html>""")
 
     self.mox.ReplayAll()
-    results = original_post_discovery.refetch(self.source)
-    self.assert_syndicated_posts(('http://author/permalink',
-                                  'https://fa.ke/changed/url'))
+    results = refetch(self.source)
+    self.assert_syndicated_posts(
+      ('http://author/permalink', 'https://fa.ke/changed/url'))
     self.assert_equals({'https://fa.ke/changed/url': list(SyndicatedPost.query())},
                        results)
 
@@ -1088,7 +959,7 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
       </html>""")
 
     self.mox.ReplayAll()
-    self.assert_equals({}, original_post_discovery.refetch(self.source))
+    self.assert_equals({}, refetch(self.source))
     self.assert_syndicated_posts(('http://author/permalink', None))
 
   def test_refetch_blank_syndication(self):
@@ -1109,9 +980,8 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
       </html>""")
 
     self.mox.ReplayAll()
-    self.assert_equals({}, original_post_discovery.refetch(self.source))
+    self.assert_equals({}, refetch(self.source))
     self.assert_syndicated_posts(('http://author/permalink', None))
-    self.assert_entities_equal([blank], list(SyndicatedPost.query()))
 
   def test_refetch_unchanged_syndication(self):
     """We should preserve unchanged SyndicatedPosts during refetches."""
@@ -1128,7 +998,7 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     </html>""")
 
     self.mox.ReplayAll()
-    original_post_discovery.refetch(self.source)
+    refetch(self.source)
     self.assert_entities_equal([synd], list(SyndicatedPost.query()))
 
   def test_malformed_url_property(self):
@@ -1150,17 +1020,13 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
 </html>""")
 
     self.mox.ReplayAll()
-    activity = original_post_discovery.discover(self.source, self.activities[0])
-    self.assertFalse(activity['object'].get('upstreamDuplicates'))
+    self.assert_discover([])
 
   def test_merge_front_page_and_h_feed(self):
     """Make sure we are correctly merging the front page and rel-feed by
     checking that we visit h-entries that are only the front page or
     only the rel-feed page.
     """
-    self.activity['upstreamDuplicates'] = ['existing uD']
-
-    # silo domain is fa.ke
     self.expect_requests_get('http://author', """
     <link rel="feed" href="/feed">
     <html class="h-feed">
@@ -1190,19 +1056,12 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
                                </div>""" % orig).InAnyOrder()
 
     self.mox.ReplayAll()
-    logging.debug('Original post discovery %s -> %s', self.source, self.activity)
-    original_post_discovery.discover(self.source, self.activity)
-
+    discover(self.source, self.activity)
     # should be three blank SyndicatedPosts now
-    for orig in ('http://author/only-on-frontpage',
-                 'http://author/on-both',
-                 'http://author/only-on-feed'):
-      logging.debug('checking %s', orig)
-      sp = SyndicatedPost.query(
-        SyndicatedPost.original == orig,
-        ancestor=self.source.key).get()
-      self.assertTrue(sp)
-      self.assertIsNone(sp.syndication)
+    self.assert_syndicated_posts(('http://author/only-on-frontpage', None),
+                                 ('http://author/on-both', None),
+                                 ('http://author/only-on-feed', None),
+                                 (None, 'https://fa.ke/post/url'))
 
   def test_match_facebook_username(self):
     """Facebook URLs use username and user id interchangeably, and one
@@ -1244,38 +1103,4 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     </html>""")
 
     self.mox.ReplayAll()
-    original_post_discovery.discover(source, self.activity)
-
-    self.assertEquals(['http://author/post/permalink'],
-                      self.activity['object']['upstreamDuplicates'])
-
-  def test_source_domains(self):
-    """Only links to the user's own domains should end up in upstreamDuplicates.
-    """
-    self.expect_requests_get('http://author', '')
-    self.mox.ReplayAll()
-
-    self.activity['object'].update({
-      'upstreamDuplicates': [],
-      'content': 'x http://author/post y',
-    })
-    original_post_discovery.discover(self.source, self.activity)
-    self.assertEquals(['http://author/post'],
-                      self.activity['object']['upstreamDuplicates'])
-
-    self.activity['object'].update({
-      'upstreamDuplicates': [],
-      'content': 'a http://other/link b',
-    })
-    original_post_discovery.discover(self.source, self.activity)
-    self.assertEquals([], self.activity['object']['upstreamDuplicates'])
-
-    # if we don't know the user's domains, we should allow anything
-    self.source.domain_urls = self.source.domains = []
-    self.source.put()
-
-    self.activity['object']['upstreamDuplicates'] = []
-    original_post_discovery.discover(self.source, self.activity)
-    self.assertEquals(['http://other/link'],
-                      self.activity['object']['upstreamDuplicates'])
-
+    self.assert_discover(['http://author/post/permalink'])

--- a/test/test_tasks.py
+++ b/test/test_tasks.py
@@ -297,7 +297,7 @@ class PollTest(TaskQueueTest):
     self.activities[0]['object'].update({'tags': [], 'content': 'http://first'})
     self.sources[0].set_activities([self.activities[0]])
 
-    too_long = 'http://' + 'x' * _MAX_STRING_LENGTH
+    too_long = 'http://host/' + 'x' * _MAX_STRING_LENGTH
     self.expect_requests_head('http://first', redirected_url=too_long)
 
     self.mox.ReplayAll()
@@ -1404,7 +1404,7 @@ class PropagateTest(TaskQueueTest):
 
     https://github.com/snarfed/bridgy/issues/273
     """
-    too_long = 'http://' + 'x' * _MAX_STRING_LENGTH
+    too_long = 'http://host/' + 'x' * _MAX_STRING_LENGTH
     self.expect_requests_head('http://target1/post/url', redirected_url=too_long)
     self.mox.ReplayAll()
 

--- a/test/test_tasks.py
+++ b/test/test_tasks.py
@@ -410,7 +410,7 @@ class PollTest(TaskQueueTest):
     self.assert_equals('complete', resp.status)
     self.assertIsNone(resp.urls_to_activity)
 
-  def test_mentions_only_go_to_posts_and_comments(self):
+  def test_only_posts_and_comments_go_to_mentions(self):
     """Response.urls_to_activity should be left unset.
     """
     self.sources[0].domains = ['foo']

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -83,18 +83,22 @@ class UtilTest(testutil.ModelsTest):
     self.assertEquals('http://target/endpoint', mention.receiver_endpoint)
 
   def test_get_webmention_target_blacklisted_urls(self):
-    for bad in ('http://facebook.com/x', 'https://www.facebook.com/y',
-                'http://sub.dom.ain.facebook.com/z'):
-      self.assertFalse(util.get_webmention_target(bad)[2], bad)
-
-    self.assertTrue(util.get_webmention_target('http://good.com/a')[2])
+    for resolve in True, False:
+      self.assertTrue(util.get_webmention_target(
+        'http://good.com/a', resolve=resolve)[2])
+      for bad in ('http://facebook.com/x', 'https://www.facebook.com/y',
+                  'http://sub.dom.ain.facebook.com/z'):
+        self.assertFalse(util.get_webmention_target(bad, resolve=resolve)[2], bad)
 
   def test_get_webmention_cleans_redirected_urls(self):
     self.expect_requests_head('http://foo/bar',
                               redirected_url='http://final?utm_source=x')
     self.mox.ReplayAll()
+
     self.assert_equals(('http://final', 'final', True),
-                       util.get_webmention_target('http://foo/bar'))
+                       util.get_webmention_target('http://foo/bar', resolve=True))
+    self.assert_equals(('http://foo/bar', 'foo', True),
+                       util.get_webmention_target('http://foo/bar', resolve=False))
 
   def test_registration_callback(self):
     """Run through an authorization back and forth and make sure that

--- a/util.py
+++ b/util.py
@@ -123,7 +123,7 @@ _orig_tag_uri = tag_uri
 util.tag_uri = lambda domain, name: _orig_tag_uri(domain, name, year=2013)
 
 
-def get_webmention_target(url, resolve=True, cache=True):
+def get_webmention_target(url, resolve=True):
   """Resolves a URL and decides whether we should try to send it a webmention.
 
   Note that this ignores failed HTTP requests, ie the boolean in the returned
@@ -132,7 +132,6 @@ def get_webmention_target(url, resolve=True, cache=True):
   Args:
     url: string
     resolve: whether to follow redirects
-    cache: whether to use memcache when following redirects
 
   Returns: (string url, string pretty domain, boolean) tuple. The boolean is
     True if we should send a webmention, False otherwise, e.g. if it's a bad
@@ -150,7 +149,7 @@ def get_webmention_target(url, resolve=True, cache=True):
   if not resolve:
     return url, domain, domain_ok(domain)
 
-  resolved = follow_redirects(url, cache=cache)
+  resolved = follow_redirects(url, cache=memcache)
   domain = domain_from_link(resolved.url).lower()
   is_html = resolved.headers.get('content-type', '').startswith('text/html')
   return util.clean_url(resolved.url), domain, domain_ok(domain) and is_html


### PR DESCRIPTION
hey @kylewm, here's the second half of the big OPD revision for #51, along with snarfed/granary#37. mind skim-reviewing both? the main changes are:

* moved the rest of OPD to `granary.source.original_post_discovery()`. now i think all of https://indiewebcamp.com/original-post-discovery that we choose to implement (heh) is there, *except* for `u-syndication` link discovery.
* converted `granary.source.original_post_discovery()` and `original_post_discovery()` to be functional: they now return original post links and mention links instead of modifying the AS object in place. most of the code churn is due to this.
* lots of other refactoring.

for #51 specifically, the new OPD logic is:

* if we know the user's domains, only interpret links as original posts if they're on one of those domains. code [here](https://github.com/snarfed/bridgy/blob/1c38c56eeec60f220b06bb619c358a370cb51215/original_post_discovery.py#L67) and [here](https://github.com/snarfed/granary/blob/0de2e917d0967d830252afc0950c247b69d6acb6/granary/source.py#L489)
* only propagate mentions in posts and comments, not in likes, reposts, or rsvps. code [here](https://github.com/snarfed/bridgy/blob/1c38c56eeec60f220b06bb619c358a370cb51215/handlers.py#L227) and below: only `PostHandler` and `CommentHandler` merge mentions. unfortunately we [still try to send webmentions for mentions for all response types](https://github.com/snarfed/bridgy/blob/1c38c56eeec60f220b06bb619c358a370cb51215/tasks.py#L241); that's a TODO for me to fix, probably before we deploy all this.

i also [tried to be careful to *always* interpret `u-syndication` links as original posts](https://github.com/snarfed/bridgy/blob/1c38c56eeec60f220b06bb619c358a370cb51215/original_post_discovery.py#L100), even if they're not on one of the user's domains.

a couple silver linings. first, i *think* the OPD logic is now easier to understand, since it's more centralized in `granary.source` and since we're not reading and writing AS objects in place everywhere.

second, the net ~200loc reduction in code is nice. mostly from `handlers.update_post_urls()`, `tasks.get_webmention_targets()` (removed entirely!), and `test_original_post_discovery` (kept all tests but reused helpers more aggressively).