### PR TITLE
Keep AS content as HTML for granary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ granary
 -e git+git@github.com:snarfed/gdata-python-client-1.git@blogger_id_parsing#egg=gdata
 google-api-python-client>=1.4.0
 beautifulsoup4
-html2text
 mf2py>=1.0.0
 mf2util>=0.2.9
 oauth2client

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -516,12 +516,14 @@ this is my article
 
     self.mox.StubOutWithMock(self.source.gr_source, 'create',
                              use_mock_anything=True)
-    self.source.gr_source.create(mox.IgnoreArg(), include_link=True
+    self.source.gr_source.create(mox.IgnoreArg(), include_link=True,
+                                 ignore_formatting=False
                                  ).AndRaise(exc.HTTPPaymentRequired('fooey'))
 
     self.mox.StubOutWithMock(self.source.gr_source, 'preview_create',
                              use_mock_anything=True)
-    self.source.gr_source.preview_create(mox.IgnoreArg(), include_link=False
+    self.source.gr_source.preview_create(mox.IgnoreArg(), include_link=False,
+                                         ignore_formatting=False
                                          ).AndRaise(Exception('bar'))
 
     self.mox.ReplayAll()
@@ -631,7 +633,8 @@ foo<br /> <blockquote>bar</blockquote>
       'displayName': 'In reply to',
       'url': 'http://foo.com/bar',
       'objectType': 'comment',
-    }, include_link=True).AndReturn(gr_source.creation_result({
+    }, include_link=True, ignore_formatting=False). \
+    AndReturn(gr_source.creation_result({
       'url': 'http://fake/url',
       'id': 'http://fake/url',
       'content': 'This is a reply',
@@ -670,7 +673,8 @@ foo<br /> <blockquote>bar</blockquote>
                  {'url': 'https://fa.ke/a/b'},
                  {'url': 'https://flic.kr/c/d'}],
       'objectType': 'activity',
-    }, include_link=True).AndReturn(gr_source.creation_result({
+    }, include_link=True, ignore_formatting=False). \
+    AndReturn(gr_source.creation_result({
       'url': 'http://fake/url',
       'id': 'http://fake/url',
       'content': 'liked this',
@@ -707,7 +711,8 @@ foo<br /> <blockquote>bar</blockquote>
       'object': [{'url': 'http://orig.domain/baz'},
                  {'url': 'https://fa.ke/a/b'}],
       'objectType': 'activity',
-    }, include_link=True).AndReturn(gr_source.creation_result({
+    }, include_link=True, ignore_formatting=False). \
+    AndReturn(gr_source.creation_result({
       'url': 'http://fake/url',
       'id': 'http://fake/url',
       'content': 'reposted this',
@@ -747,7 +752,8 @@ foo<br /> <blockquote>bar</blockquote>
       'object': [{'url': 'http://orig.domain/baz'},
                  {'url': 'https://fa.ke/a/b'}],
       'objectType': 'activity',
-    }, include_link=True).AndReturn(gr_source.creation_result({
+    }, include_link=True, ignore_formatting=False). \
+    AndReturn(gr_source.creation_result({
       'url': 'http://fake/url',
       'id': 'http://fake/url',
       'content': 'RSVPd yes',
@@ -777,7 +783,8 @@ foo<br /> <blockquote>bar</blockquote>
       'displayName': 'In reply to',
       'url': 'http://foo.com/bar',
       'objectType': 'comment',
-    }, include_link=True).AndReturn(gr_source.creation_result({
+    }, include_link=True, ignore_formatting=False). \
+    AndReturn(gr_source.creation_result({
       'url': 'http://fake/url',
       'id': 'http://fake/url',
       'content': 'This is a reply',
@@ -812,7 +819,8 @@ foo<br /> <blockquote>bar</blockquote>
       'url': 'http://foo.com/bar',
       'object': [{'url': 'http://orig.domain/baz'}],
       'objectType': 'activity',
-    }, include_link=True).AndReturn(gr_source.creation_result({
+    }, include_link=True, ignore_formatting=False). \
+    AndReturn(gr_source.creation_result({
       'url': 'http://fake/url',
       'id': 'http://fake/url',
       'content': 'liked this',
@@ -843,8 +851,9 @@ foo<br /> <blockquote>bar</blockquote>
       'displayName': 'yes',
       'object': [{'url': 'http://fa.ke/homebrew-website-club'}],
       'objectType': 'activity',
-      'content': 'yes',
-    }, include_link=True).AndReturn(gr_source.creation_result({
+      'content': '\n<span class="p-rsvp" value="yes">yes</span>\n<a class="u-in-reply-to" href="http://fa.ke/homebrew-website-club"></a>\n',
+    }, include_link=True, ignore_formatting=False). \
+    AndReturn(gr_source.creation_result({
       'url': 'http://fake/url',
       'id': 'http://fake/url',
       'content': 'RSVPd yes',
@@ -1024,7 +1033,7 @@ Join us!"""
     obj = {
       'objectType': 'note',
       'url': 'http://foo.com/bar',
-      'content': 'my message',
+      'content': '\nmy message\n',
       'displayName': 'my message\n\nUnknown,444,Username,Inferred,Unknown,My.domain',
       'tags': [{
         'objectType': 'person',
@@ -1049,11 +1058,13 @@ my message
     self.mox.StubOutWithMock(self.source.gr_source, 'create',
                              use_mock_anything=True)
     result = gr_source.creation_result(content={'content': 'my message'})
-    self.source.gr_source.create(obj, include_link=True).AndReturn(result)
+    self.source.gr_source.create(obj, include_link=True,
+                                 ignore_formatting=False).AndReturn(result)
 
     self.mox.StubOutWithMock(self.source.gr_source, 'preview_create',
                              use_mock_anything=True)
-    self.source.gr_source.preview_create(obj, include_link=False).AndReturn(result)
+    self.source.gr_source.preview_create(obj, include_link=False,
+                                         ignore_formatting=False).AndReturn(result)
     self.mox.ReplayAll()
 
     self.assert_created('my message', interactive=False,

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -121,7 +121,7 @@ class FakeGrSource(FakeBase, gr_source.Source):
   def user_to_actor(self, user):
     return user
 
-  def create(self, obj, include_link=False):
+  def create(self, obj, include_link=False, ignore_formatting=False):
     verb = obj.get('verb')
     type = obj.get('objectType')
     if verb == 'like':
@@ -141,19 +141,25 @@ class FakeGrSource(FakeBase, gr_source.Source):
           error_plain='no %s url to reply to' % self.DOMAIN,
           error_html='no %s url to reply to' % self.DOMAIN)
 
-    content = obj['content'] + (' - %s' % obj['url'] if include_link else '')
+    content = self._content_for_create(obj, ignore_formatting=ignore_formatting)
+    if include_link:
+        content += ' - %s' % obj['url']
     ret = {'id': 'fake id', 'url': 'http://fake/url', 'content': content}
     if verb == 'rsvp-yes':
       ret['type'] = 'post'
     return gr_source.creation_result(ret)
 
-  def preview_create(self, obj, include_link=False):
+  def preview_create(self, obj, include_link=False, ignore_formatting=False):
     if obj.get('verb') == 'like':
       return gr_source.creation_result(
         abort=True, error_plain='Cannot publish likes',
         error_html='Cannot publish likes')
-    content = 'preview of ' + obj['content'] + (' - %s' % obj['url']
-                                                if include_link else '')
+
+    content = self._content_for_create(obj, ignore_formatting=ignore_formatting)
+    if include_link:
+        content += ' - %s' % obj['url']
+
+    content = 'preview of ' + content
     return gr_source.creation_result(description=content)
 
 


### PR DESCRIPTION
Granary produces it as HTML, and now consumes it as HTML.  This allows
more control over silo-specific formatting, but more importantly allows
us to implement silos that support HTML formatting (such as medium).

See also: https://github.com/snarfed/granary/pull/62