### PR TITLE
PPD: look for h-feed anywhere on page

### DIFF
--- a/original_post_discovery.py
+++ b/original_post_discovery.py
@@ -29,6 +29,7 @@ import datetime
 import itertools
 import logging
 import mf2py
+import mf2util
 import requests
 import urlparse
 import util
@@ -386,10 +387,10 @@ def _find_feed_items(feed_url, feed_doc):
   Returns:
     a list of dicts, each one representing an mf2 h-* item
   """
-  parsed = mf2py.Parser(url=feed_url, doc=feed_doc).to_dict()
+  parsed = mf2py.parse(url=feed_url, doc=feed_doc)
+
   feeditems = parsed['items']
-  hfeed = next((item for item in feeditems
-                if 'h-feed' in item['type']), None)
+  hfeed = mf2util.find_first_entry(parsed, ('h-feed',))
   if hfeed:
     feeditems = hfeed.get('children', [])
   else:

--- a/test/test_original_post_discovery.py
+++ b/test/test_original_post_discovery.py
@@ -108,6 +108,32 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
     self.assert_syndicated_posts(('http://author/post/final',
                                   'https://fa.ke/post/url'))
 
+  def test_nested_hfeed(self):
+    """Test that we find an h-feed nested inside an h-card like on
+    tantek.com"""
+    self.expect_requests_get('http://author', """
+    <html class="h-card">
+      <span class="p-name">Author</span>
+      <div class="h-feed">
+        <div class="h-entry">
+          <a class="u-url" href="http://author/post/permalink"></a>
+        </div>
+      </div>
+    </html>
+    """)
+
+    self.expect_requests_get('http://author/post/permalink', """
+    <html class="h-entry">
+      <a class="u-url" href="http://author/post/permalink"></a>
+      <a class="u-syndication" href="https://fa.ke/post/url"></a>
+    </html>
+    """)
+
+    self.mox.ReplayAll()
+    self.assert_discover(['http://author/post/permalink'])
+    self.assert_syndicated_posts(('http://author/post/permalink',
+                                  'https://fa.ke/post/url'))
+
   def test_additional_requests_do_not_require_rework(self):
     """Test that original post discovery fetches and stores all entries up
     front so that it does not have to reparse the author's h-feed for


### PR DESCRIPTION
use mf2util.find_first_entry to BFS the page for h-feed, instead
of only allowing the root to be h-feed.

fixes #584