### PR TITLE
rename Source.last_hfeed_fetch to last_refetch

### DIFF
--- a/app.py
+++ b/app.py
@@ -532,7 +532,7 @@ class CrawlNowHandler(PollNowHandler):
   @ndb.transactional
   def setup_refetch_hfeed(self):
     self.get_source()
-    self.source.last_refetch = models.REFETCH_HFEED_TRIGGER
+    self.source.last_hfeed_refetch = models.REFETCH_HFEED_TRIGGER
     self.source.put()
 
 

--- a/app.py
+++ b/app.py
@@ -532,7 +532,7 @@ class CrawlNowHandler(PollNowHandler):
   @ndb.transactional
   def setup_refetch_hfeed(self):
     self.get_source()
-    self.source.last_hfeed_fetch = models.REFETCH_HFEED_TRIGGER
+    self.source.last_refetch = models.REFETCH_HFEED_TRIGGER
     self.source.put()
 
 

--- a/models.py
+++ b/models.py
@@ -115,9 +115,9 @@ class Source(StringIdModel):
 
   # the last time we re-fetched the author's url looking for updated
   # syndication links
-  last_refetch = ndb.DateTimeProperty(default=util.EPOCH)
+  last_hfeed_refetch = ndb.DateTimeProperty(default=util.EPOCH)
 
-  # Deprecated; old name for last_refetch
+  # Deprecated; old name for last_hfeed_refetch
   last_hfeed_fetch = ndb.DateTimeProperty(default=util.EPOCH)
 
   # the last time we've seen a rel=syndication link for this Source.
@@ -405,7 +405,7 @@ class Source(StringIdModel):
       # merge some fields
       source.features = set(source.features + existing.features)
       source.populate(**existing.to_dict(include=(
-            'created', 'last_refetch', 'last_hfeed_fetch', 'last_poll_attempt', 'last_polled',
+            'created', 'last_hfeed_refetch', 'last_hfeed_fetch', 'last_poll_attempt', 'last_polled',
             'last_syndication_url', 'last_webmention_sent', 'superfeedr_secret')))
       verb = 'Updated'
     else:

--- a/models.py
+++ b/models.py
@@ -115,6 +115,9 @@ class Source(StringIdModel):
 
   # the last time we re-fetched the author's url looking for updated
   # syndication links
+  last_refetch = ndb.DateTimeProperty(default=util.EPOCH)
+
+  # Deprecated; old name for last_refetch
   last_hfeed_fetch = ndb.DateTimeProperty(default=util.EPOCH)
 
   # the last time we've seen a rel=syndication link for this Source.
@@ -402,7 +405,7 @@ class Source(StringIdModel):
       # merge some fields
       source.features = set(source.features + existing.features)
       source.populate(**existing.to_dict(include=(
-            'created', 'last_hfeed_fetch', 'last_poll_attempt', 'last_polled',
+            'created', 'last_refetch', 'last_hfeed_fetch', 'last_poll_attempt', 'last_polled',
             'last_syndication_url', 'last_webmention_sent', 'superfeedr_secret')))
       verb = 'Updated'
     else:

--- a/original_post_discovery.py
+++ b/original_post_discovery.py
@@ -150,10 +150,6 @@ def refetch(source):
   for url in _get_author_urls(source):
     results.update(_process_author(source, url, refetch=True))
 
-  now = util.now_fn()
-  logging.debug('updating source last_hfeed_fetch %s', now)
-  source.updates['last_hfeed_fetch'] = now
-
   return results
 
 
@@ -207,10 +203,6 @@ def _posse_post_discovery(source, activity, syndication_url, fetch_hfeed):
     for url in _get_author_urls(source):
       results.update(_process_author(source, url))
     relationships = results.get(syndication_url, [])
-
-    now = util.now_fn()
-    logging.debug('updating source last_hfeed_fetch %s', now)
-    source.updates['last_hfeed_fetch'] = util.now_fn()
 
   if not relationships:
     # No relationships were found. Remember that we've seen this

--- a/tasks.py
+++ b/tasks.py
@@ -339,12 +339,21 @@ class Poll(webapp2.RequestHandler):
     # original_post_discovery ran, we'll miss them. this cleanup task will
     # periodically check for updated urls. only kicks in if the author has
     # *ever* published a rel=syndication url
-    if (source.last_hfeed_fetch == models.REFETCH_HFEED_TRIGGER or
+    last_refetch = source.last_refetch
+    if not last_refetch or (source.last_hfeed_fetch and source.last_hfeed_fetch > last_refetch):
+      last_refetch = source.last_hfeed_fetch
+
+    if (last_refetch == models.REFETCH_HFEED_TRIGGER or
         (source.last_syndication_url and
-         source.last_hfeed_fetch + source.refetch_period()
+         last_refetch + source.refetch_period()
            <= source.last_poll_attempt)):
       logging.info('refetching h-feed for source %s', source.label())
       relationships = original_post_discovery.refetch(source)
+
+      now = util.now_fn()
+      logging.debug('updating source last_refetch %s', now)
+      source.updates['last_refetch'] = now
+
       if relationships:
         logging.info('refetch h-feed found new rel=syndication relationships: %s',
                      relationships)
@@ -359,8 +368,8 @@ class Poll(webapp2.RequestHandler):
             raise
     else:
       logging.info(
-          'skipping refetch h-feed. last-syndication-url %s, last-hfeed-fetch %s',
-          source.last_syndication_url, source.last_hfeed_fetch)
+          'skipping refetch h-feed. last-syndication-url %s, last-refetch %s',
+          source.last_syndication_url, source.last_refetch)
 
   def repropagate_old_responses(self, source, relationships):
     """Find old Responses that match a new SyndicatedPost and repropagate them.

--- a/tasks.py
+++ b/tasks.py
@@ -339,20 +339,20 @@ class Poll(webapp2.RequestHandler):
     # original_post_discovery ran, we'll miss them. this cleanup task will
     # periodically check for updated urls. only kicks in if the author has
     # *ever* published a rel=syndication url
-    last_refetch = source.last_refetch
-    if not last_refetch or (source.last_hfeed_fetch and source.last_hfeed_fetch > last_refetch):
-      last_refetch = source.last_hfeed_fetch
+    last_hfeed_refetch = source.last_hfeed_refetch
+    if not last_hfeed_refetch or (last_hfeed_refetch != models.REFETCH_HFEED_TRIGGER and source.last_hfeed_fetch and source.last_hfeed_fetch > last_hfeed_refetch):
+      last_hfeed_refetch = source.last_hfeed_fetch
 
-    if (last_refetch == models.REFETCH_HFEED_TRIGGER or
+    if (last_hfeed_refetch == models.REFETCH_HFEED_TRIGGER or
         (source.last_syndication_url and
-         last_refetch + source.refetch_period()
+         last_hfeed_refetch + source.refetch_period()
            <= source.last_poll_attempt)):
       logging.info('refetching h-feed for source %s', source.label())
       relationships = original_post_discovery.refetch(source)
 
       now = util.now_fn()
-      logging.debug('updating source last_refetch %s', now)
-      source.updates['last_refetch'] = now
+      logging.debug('updating source last_hfeed_refetch %s', now)
+      source.updates['last_hfeed_refetch'] = now
 
       if relationships:
         logging.info('refetch h-feed found new rel=syndication relationships: %s',
@@ -369,7 +369,7 @@ class Poll(webapp2.RequestHandler):
     else:
       logging.info(
           'skipping refetch h-feed. last-syndication-url %s, last-refetch %s',
-          source.last_syndication_url, source.last_refetch)
+          source.last_syndication_url, source.last_hfeed_refetch)
 
   def repropagate_old_responses(self, source, relationships):
     """Find old Responses that match a new SyndicatedPost and repropagate them.

--- a/templates/social_user.html
+++ b/templates/social_user.html
@@ -120,19 +120,19 @@ WordPress.com, <a href="/">sign up here!</a>
   <br />
 {% endif %}
 
-<!-- last_hfeed_fetch -->
+<!-- last_refetch -->
 {% if source.domain_urls %}
 <form method="post" action="/crawl-now">
 {% with source.domain_urls|length|pluralize as s %}
-{% if source.last_hfeed_fetch == epoch %}
+{% if source.last_refetch == epoch %}
   Web site{{ s }} not <a href="/about#link">crawled</a> yet.
 {% else %}
   Web site{{ s }} <a href="/about#link">crawled</a>
-  <a href="/log?start_time={{ source.last_hfeed_fetch|date:'U' }}&key={{ source.key.urlsafe }}"
-       title="{{ source.last_hfeed_fetch|date:'r' }}">
-  <time class="dt-bridgy-last-hfeed-fetched"
-        datetime="{{ source.last_hfeed_fetch|date:'c' }}">
-    {{ source.last_hfeed_fetch|timesince }}</time> ago.
+  <a href="/log?start_time={{ source.last_refetch|date:'U' }}&key={{ source.key.urlsafe }}"
+       title="{{ source.last_refetch|date:'r' }}">
+  <time class="dt-bridgy-last-refetched"
+        datetime="{{ source.last_refetch|date:'c' }}">
+    {{ source.last_refetch|timesince }}</time> ago.
   </a>
 {% endif %}
 {% endwith %}

--- a/templates/social_user.html
+++ b/templates/social_user.html
@@ -120,19 +120,19 @@ WordPress.com, <a href="/">sign up here!</a>
   <br />
 {% endif %}
 
-<!-- last_refetch -->
+<!-- last_hfeed_refetch -->
 {% if source.domain_urls %}
 <form method="post" action="/crawl-now">
 {% with source.domain_urls|length|pluralize as s %}
-{% if source.last_refetch == epoch %}
+{% if source.last_hfeed_refetch == epoch %}
   Web site{{ s }} not <a href="/about#link">crawled</a> yet.
 {% else %}
   Web site{{ s }} <a href="/about#link">crawled</a>
-  <a href="/log?start_time={{ source.last_refetch|date:'U' }}&key={{ source.key.urlsafe }}"
-       title="{{ source.last_refetch|date:'r' }}">
+  <a href="/log?start_time={{ source.last_hfeed_refetch|date:'U' }}&key={{ source.key.urlsafe }}"
+       title="{{ source.last_hfeed_refetch|date:'r' }}">
   <time class="dt-bridgy-last-refetched"
-        datetime="{{ source.last_refetch|date:'c' }}">
-    {{ source.last_refetch|timesince }}</time> ago.
+        datetime="{{ source.last_hfeed_refetch|date:'c' }}">
+    {{ source.last_hfeed_refetch|timesince }}</time> ago.
   </a>
 {% endif %}
 {% endwith %}

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -44,7 +44,7 @@ class AppTest(testutil.ModelsTest):
 
     source = self.sources[0]
     source.domain_urls = ['http://orig']
-    source.last_refetch = last_refetch = \
+    source.last_hfeed_refetch = last_hfeed_refetch = \
         testutil.NOW - datetime.timedelta(minutes=1)
     source.put()
 
@@ -93,7 +93,7 @@ class AppTest(testutil.ModelsTest):
     self.assertIsNone(memcache.get('W https skipped'))
 
     # shouldn't have refetched h-feed
-    self.assertEqual(last_refetch, source.key.get().last_refetch)
+    self.assertEqual(last_hfeed_refetch, source.key.get().last_hfeed_refetch)
 
   def test_retry_redirect_to(self):
     key = self.responses[0].put()
@@ -106,7 +106,7 @@ class AppTest(testutil.ModelsTest):
   def test_crawl_now(self):
     source = self.sources[0]
     source.domain_urls = ['http://orig']
-    source.last_refetch = testutil.NOW
+    source.last_hfeed_refetch = testutil.NOW
     source.put()
 
     key = source.key.urlsafe()
@@ -118,7 +118,7 @@ class AppTest(testutil.ModelsTest):
 
     params = testutil.get_task_params(self.taskqueue_stub.GetTasks('poll-now')[0])
     self.assertEqual(key, params['source_key'])
-    self.assertEqual(models.REFETCH_HFEED_TRIGGER, source.key.get().last_refetch)
+    self.assertEqual(models.REFETCH_HFEED_TRIGGER, source.key.get().last_hfeed_refetch)
 
   def test_poll_now_and_retry_response_missing_key(self):
     for endpoint in '/poll-now', '/retry':

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -44,7 +44,7 @@ class AppTest(testutil.ModelsTest):
 
     source = self.sources[0]
     source.domain_urls = ['http://orig']
-    source.last_hfeed_fetch = last_hfeed_fetch = \
+    source.last_refetch = last_refetch = \
         testutil.NOW - datetime.timedelta(minutes=1)
     source.put()
 
@@ -93,7 +93,7 @@ class AppTest(testutil.ModelsTest):
     self.assertIsNone(memcache.get('W https skipped'))
 
     # shouldn't have refetched h-feed
-    self.assertEqual(last_hfeed_fetch, source.key.get().last_hfeed_fetch)
+    self.assertEqual(last_refetch, source.key.get().last_refetch)
 
   def test_retry_redirect_to(self):
     key = self.responses[0].put()
@@ -106,7 +106,7 @@ class AppTest(testutil.ModelsTest):
   def test_crawl_now(self):
     source = self.sources[0]
     source.domain_urls = ['http://orig']
-    source.last_hfeed_fetch = testutil.NOW
+    source.last_refetch = testutil.NOW
     source.put()
 
     key = source.key.urlsafe()
@@ -118,7 +118,7 @@ class AppTest(testutil.ModelsTest):
 
     params = testutil.get_task_params(self.taskqueue_stub.GetTasks('poll-now')[0])
     self.assertEqual(key, params['source_key'])
-    self.assertEqual(models.REFETCH_HFEED_TRIGGER, source.key.get().last_hfeed_fetch)
+    self.assertEqual(models.REFETCH_HFEED_TRIGGER, source.key.get().last_refetch)
 
   def test_poll_now_and_retry_response_missing_key(self):
     for endpoint in '/poll-now', '/retry':
@@ -260,4 +260,3 @@ class AppTest(testutil.ModelsTest):
                       resp.headers['Set-Cookie'])
     self.assertEquals(302, resp.status_int)
     self.assertEquals('http://localhost/#!Logged%20out.', resp.headers['Location'])
-

--- a/test/test_facebook.py
+++ b/test/test_facebook.py
@@ -326,7 +326,7 @@ class FacebookPageTest(testutil.ModelsTest):
     Background in https://github.com/snarfed/bridgy/issues/189
     """
     self.fb.domain_urls = ['http://author/url']
-    self.fb.last_refetch = testutil.NOW
+    self.fb.last_hfeed_refetch = testutil.NOW
     self.fb.put()
 
     # Facebook API calls

--- a/test/test_facebook.py
+++ b/test/test_facebook.py
@@ -325,8 +325,8 @@ class FacebookPageTest(testutil.ModelsTest):
 
     Background in https://github.com/snarfed/bridgy/issues/189
     """
-    self.fb.domain_urls=['http://author/url']
-    self.fb.last_hfeed_fetch = testutil.NOW
+    self.fb.domain_urls = ['http://author/url']
+    self.fb.last_refetch = testutil.NOW
     self.fb.put()
 
     # Facebook API calls

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -247,7 +247,7 @@ class SourceTest(testutil.HandlerTest):
       'created': long_ago,
       'last_webmention_sent': long_ago + datetime.timedelta(days=1),
       'last_polled': long_ago + datetime.timedelta(days=2),
-      'last_refetch': long_ago + datetime.timedelta(days=3),
+      'last_hfeed_refetch': long_ago + datetime.timedelta(days=3),
       'last_syndication_url': long_ago + datetime.timedelta(days=4),
       'superfeedr_secret': 'asdfqwert',
       }

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -247,7 +247,7 @@ class SourceTest(testutil.HandlerTest):
       'created': long_ago,
       'last_webmention_sent': long_ago + datetime.timedelta(days=1),
       'last_polled': long_ago + datetime.timedelta(days=2),
-      'last_hfeed_fetch': long_ago + datetime.timedelta(days=3),
+      'last_refetch': long_ago + datetime.timedelta(days=3),
       'last_syndication_url': long_ago + datetime.timedelta(days=4),
       'superfeedr_secret': 'asdfqwert',
       }

--- a/test/test_tasks.py
+++ b/test/test_tasks.py
@@ -949,7 +949,7 @@ class PollTest(TaskQueueTest):
     FakeGrSource.DOMAIN = 'source'
     ten_min = datetime.timedelta(minutes=10)
     self.sources[0].last_syndication_url = NOW - ten_min
-    self.sources[0].last_refetch = NOW - models.Source.REFETCH_PERIOD - ten_min
+    self.sources[0].last_hfeed_refetch = NOW - models.Source.REFETCH_PERIOD - ten_min
     self.sources[0].put()
 
     # pretend we've already done posse-post-discovery for the source
@@ -970,12 +970,12 @@ class PollTest(TaskQueueTest):
     sure it is not fetched again."""
     self._setup_refetch_hfeed()
     # too recent to fetch again
-    self.sources[0].last_refetch = hour_ago = NOW - datetime.timedelta(hours=1)
+    self.sources[0].last_hfeed_refetch = hour_ago = NOW - datetime.timedelta(hours=1)
     self.sources[0].put()
 
     self.mox.ReplayAll()
     self.post_task()
-    self.assertEquals(hour_ago, self.sources[0].key.get().last_refetch)
+    self.assertEquals(hour_ago, self.sources[0].key.get().last_hfeed_refetch)
 
     # should still be a blank SyndicatedPost
     relationships = SyndicatedPost.query(
@@ -1046,13 +1046,13 @@ class PollTest(TaskQueueTest):
 
     source = self.sources[0].key.get()
     self.assertEquals(NOW, source.last_syndication_url)
-    self.assertEquals(NOW, source.last_refetch)
+    self.assertEquals(NOW, source.last_hfeed_refetch)
 
   def test_refetch_hfeed_trigger(self):
     self.sources[0].domain_urls = ['http://author']
     FakeGrSource.DOMAIN = 'source'
     self.sources[0].last_syndication_url = None
-    self.sources[0].last_refetch = models.REFETCH_HFEED_TRIGGER
+    self.sources[0].last_hfeed_refetch = models.REFETCH_HFEED_TRIGGER
     self.sources[0].put()
 
     FakeGrSource.activities = []
@@ -1087,7 +1087,7 @@ class PollTest(TaskQueueTest):
 
     # should 200
     self.post_task()
-    self.assertEquals(NOW, self.sources[0].key.get().last_refetch)
+    self.assertEquals(NOW, self.sources[0].key.get().last_hfeed_refetch)
 
   def test_no_duplicate_syndicated_posts(self):
     def assert_syndicated_posts(syndicated_posts, original, syndication):
@@ -1109,7 +1109,7 @@ class PollTest(TaskQueueTest):
       None,
       domain_urls=['http://author'],
       features=['listen'],
-      last_refetch=NOW,
+      last_hfeed_refetch=NOW,
       last_syndication_url=util.EPOCH)
 
     for act in self.activities:
@@ -1131,7 +1131,7 @@ class PollTest(TaskQueueTest):
       None,
       domain_urls=['http://author'],
       features=['listen'],
-      last_refetch=NOW,
+      last_hfeed_refetch=NOW,
       last_syndication_url=util.EPOCH)
 
     twitter_acts = copy.deepcopy(self.activities)
@@ -1192,7 +1192,7 @@ class PollTest(TaskQueueTest):
     # force refetch h-feed to find the twitter link
     for source in self.sources:
       source.last_polled = util.EPOCH
-      source.last_refetch = NOW - datetime.timedelta(days=1)
+      source.last_hfeed_refetch = NOW - datetime.timedelta(days=1)
       source.put()
 
     # instagram source fetches
@@ -1223,7 +1223,7 @@ class PollTest(TaskQueueTest):
     for source in self.sources:
       source = source.key.get()
       self.post_task(source=source)
-      self.assertEquals(NOW, source.key.get().last_refetch)
+      self.assertEquals(NOW, source.key.get().last_hfeed_refetch)
 
     assert_syndicated_posts(
       SyndicatedPost.query(

--- a/test/test_tasks.py
+++ b/test/test_tasks.py
@@ -924,7 +924,7 @@ class PollTest(TaskQueueTest):
 
   def test_set_last_syndication_url(self):
     """A successful posse-post-discovery round should set
-    last_syndication_url and last_hfeed_fetch to approximately the current time.
+    last_syndication_url to approximately the current time.
     """
     self.sources[0].domain_urls = ['http://author']
     FakeGrSource.DOMAIN = 'source'
@@ -943,14 +943,13 @@ class PollTest(TaskQueueTest):
     # query source
     source = self.sources[0].key.get()
     self.assertEquals(NOW, source.last_syndication_url)
-    self.assertEquals(NOW, source.last_hfeed_fetch)
 
   def _setup_refetch_hfeed(self):
     self.sources[0].domain_urls = ['http://author']
     FakeGrSource.DOMAIN = 'source'
     ten_min = datetime.timedelta(minutes=10)
     self.sources[0].last_syndication_url = NOW - ten_min
-    self.sources[0].last_hfeed_fetch = NOW - models.Source.REFETCH_PERIOD - ten_min
+    self.sources[0].last_refetch = NOW - models.Source.REFETCH_PERIOD - ten_min
     self.sources[0].put()
 
     # pretend we've already done posse-post-discovery for the source
@@ -971,12 +970,12 @@ class PollTest(TaskQueueTest):
     sure it is not fetched again."""
     self._setup_refetch_hfeed()
     # too recent to fetch again
-    self.sources[0].last_hfeed_fetch = hour_ago = NOW - datetime.timedelta(hours=1)
+    self.sources[0].last_refetch = hour_ago = NOW - datetime.timedelta(hours=1)
     self.sources[0].put()
 
     self.mox.ReplayAll()
     self.post_task()
-    self.assertEquals(hour_ago, self.sources[0].key.get().last_hfeed_fetch)
+    self.assertEquals(hour_ago, self.sources[0].key.get().last_refetch)
 
     # should still be a blank SyndicatedPost
     relationships = SyndicatedPost.query(
@@ -1047,13 +1046,13 @@ class PollTest(TaskQueueTest):
 
     source = self.sources[0].key.get()
     self.assertEquals(NOW, source.last_syndication_url)
-    self.assertEquals(NOW, source.last_hfeed_fetch)
+    self.assertEquals(NOW, source.last_refetch)
 
   def test_refetch_hfeed_trigger(self):
     self.sources[0].domain_urls = ['http://author']
     FakeGrSource.DOMAIN = 'source'
     self.sources[0].last_syndication_url = None
-    self.sources[0].last_hfeed_fetch = models.REFETCH_HFEED_TRIGGER
+    self.sources[0].last_refetch = models.REFETCH_HFEED_TRIGGER
     self.sources[0].put()
 
     FakeGrSource.activities = []
@@ -1088,7 +1087,7 @@ class PollTest(TaskQueueTest):
 
     # should 200
     self.post_task()
-    self.assertEquals(NOW, self.sources[0].key.get().last_hfeed_fetch)
+    self.assertEquals(NOW, self.sources[0].key.get().last_refetch)
 
   def test_no_duplicate_syndicated_posts(self):
     def assert_syndicated_posts(syndicated_posts, original, syndication):
@@ -1110,7 +1109,7 @@ class PollTest(TaskQueueTest):
       None,
       domain_urls=['http://author'],
       features=['listen'],
-      last_hfeed_fetch=NOW,
+      last_refetch=NOW,
       last_syndication_url=util.EPOCH)
 
     for act in self.activities:
@@ -1132,7 +1131,7 @@ class PollTest(TaskQueueTest):
       None,
       domain_urls=['http://author'],
       features=['listen'],
-      last_hfeed_fetch=NOW,
+      last_refetch=NOW,
       last_syndication_url=util.EPOCH)
 
     twitter_acts = copy.deepcopy(self.activities)
@@ -1193,7 +1192,7 @@ class PollTest(TaskQueueTest):
     # force refetch h-feed to find the twitter link
     for source in self.sources:
       source.last_polled = util.EPOCH
-      source.last_hfeed_fetch = NOW - datetime.timedelta(days=1)
+      source.last_refetch = NOW - datetime.timedelta(days=1)
       source.put()
 
     # instagram source fetches
@@ -1224,7 +1223,7 @@ class PollTest(TaskQueueTest):
     for source in self.sources:
       source = source.key.get()
       self.post_task(source=source)
-      self.assertEquals(NOW, source.key.get().last_hfeed_fetch)
+      self.assertEquals(NOW, source.key.get().last_refetch)
 
     assert_syndicated_posts(
       SyndicatedPost.query(


### PR DESCRIPTION
Also, do not set last_refetch when fetching an h-feed normally. We
only care about how long it's been since the last *full* refetch.