### PR TITLE
eliminate repeated fetches of the author's homepage

### DIFF
--- a/models.py
+++ b/models.py
@@ -117,9 +117,6 @@ class Source(StringIdModel):
   # syndication links
   last_hfeed_refetch = ndb.DateTimeProperty(default=util.EPOCH)
 
-  # Deprecated; old name for last_hfeed_refetch
-  last_hfeed_fetch = ndb.DateTimeProperty(default=util.EPOCH)
-
   # the last time we've seen a rel=syndication link for this Source.
   # we won't spend the time to re-fetch and look for updates if there's
   # never been one
@@ -405,7 +402,7 @@ class Source(StringIdModel):
       # merge some fields
       source.features = set(source.features + existing.features)
       source.populate(**existing.to_dict(include=(
-            'created', 'last_hfeed_refetch', 'last_hfeed_fetch', 'last_poll_attempt', 'last_polled',
+            'created', 'last_hfeed_refetch', 'last_poll_attempt', 'last_polled',
             'last_syndication_url', 'last_webmention_sent', 'superfeedr_secret')))
       verb = 'Updated'
     else:

--- a/tasks.py
+++ b/tasks.py
@@ -189,7 +189,7 @@ class Poll(webapp2.RequestHandler):
 
     # Make sure we only fetch the author's h-feed(s) the first time
     # discover is called
-    is_first_discover = util.FirstCheck()
+    is_first_discover = True
 
     #
     # Step 2: extract responses, store their activities in response['activities']
@@ -214,8 +214,9 @@ class Poll(webapp2.RequestHandler):
           if tag.get('objectType') == 'person' and tag.get('id') == user_id and urls:
             activity['originals'], activity['mentions'] = \
               original_post_discovery.discover(
-                source, activity, fetch_hfeed=is_first_discover(),
+                source, activity, fetch_hfeed=is_first_discover,
                 include_redirect_sources=False)
+            is_first_discover = False
             activity['mentions'].update(u.get('value') for u in urls)
             responses[id] = activity
             break
@@ -229,8 +230,9 @@ class Poll(webapp2.RequestHandler):
           if 'originals' not in activity or 'mentions' not in activity:
             activity['originals'], activity['mentions'] = \
               original_post_discovery.discover(
-                source, activity, fetch_hfeed=is_first_discover(),
+                source, activity, fetch_hfeed=is_first_discover,
                 include_redirect_sources=False)
+            is_first_discover = False
           responses[id] = activity
           break
 
@@ -294,8 +296,9 @@ class Poll(webapp2.RequestHandler):
         if 'originals' not in activity or 'mentions' not in activity:
           activity['originals'], activity['mentions'] = \
             original_post_discovery.discover(
-              source, activity, fetch_hfeed=is_first_discover(),
+              source, activity, fetch_hfeed=is_first_discover,
               include_redirect_sources=False)
+          is_first_discover = False
 
         targets = original_post_discovery.targets_for_response(
           resp, originals=activity['originals'], mentions=activity['mentions'])

--- a/util.py
+++ b/util.py
@@ -561,16 +561,3 @@ class CachedPage(StringIdModel):
   def invalidate(cls, path):
     logging.info('Deleting cached page for %s', path)
     CachedPage(id=path).key.delete()
-
-
-class FirstCheck:
-  """A callable that returns True the first time it is called, and false
-  every time thereafter.
-  """
-  def __init__(self):
-    self.is_first = True
-
-  def __call__(self):
-    result = self.is_first
-    self.is_first = False
-    return result

--- a/util.py
+++ b/util.py
@@ -561,3 +561,16 @@ class CachedPage(StringIdModel):
   def invalidate(cls, path):
     logging.info('Deleting cached page for %s', path)
     CachedPage(id=path).key.delete()
+
+
+class FirstCheck:
+  """A callable that returns True the first time it is called, and false
+  every time thereafter.
+  """
+  def __init__(self):
+    self.is_first = True
+
+  def __call__(self):
+    result = self.is_first
+    self.is_first = False
+    return result


### PR DESCRIPTION
when calling discover() multiple times in succession, only allow fetch_hfeed
to be true on the first one. we've already found all the relationships we're
going to find on the first call.

(also removed references to "last_hfeed_fetch" which was renamed to
"last_hfeed_refetch earlier today)

fixes #597