### PR TITLE
add tags to Flickr support, people rather than user

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -658,8 +658,9 @@ previewing a post to see how it will look!
     photos or videos</a>
   <a href="http://instagram.com/developer/endpoints/comments/#post_media_comments">or
   comments</a>.</li>
-<li>Flickr photos, comments, and favorites. Photos may include
-  <a href="http://indiewebcamp.com/person-tag">user tags</a>.</li>
+<li>Flickr photos, comments, and favorites. Photos may include 
+  <a href="https://indiewebcamp.com/tags">tags</a> and/or
+  <a href="https://indiewebcamp.com/person-tag">people tags</a>.</li>
 <li>Nothing on Google+, sorry.
   <a href="https://developers.google.com/+/api/latest/">Their API is
     read only.</a></li>


### PR DESCRIPTION
note that Flickr publish support supports tags, and call them people tags since the Flickr feature is called "People in photo", "Add people"