### PR TITLE
Add support for multiple users on the same domain

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -163,14 +163,25 @@ class Handler(webmention.WebmentionHandler):
       return self.error("Could not find <b>%(type)s</b> account for <b>%(domain)s</b>. Check that your %(type)s profile has %(domain)s in its <em>web site</em> or <em>link</em> field, then try signing up again." %
         {'type': source_cls.GR_CLASS.NAME, 'domain': domain})
 
+    publish = False
+    previous_url = ""
     for source in sources:
       logging.info('Source: %s , features %s, status %s, poll status %s',
                    source.bridgy_url(self), source.features, source.status,
                    source.poll_status)
       if source.status != 'disabled' and 'publish' in source.features:
-        self.source = source
-        break
-    else:
+        publish = True
+        # start with the first provided source, then check the rest for
+        # closer matches between the current url and provided domain_urls.
+        if previous_url == "":
+          self.source = source
+
+        for domain_url in source.domain_urls:
+          if (url.startswith(domain_url) and len(domain_url) > len(previous_url)):
+            self.source = source
+            previous_url = domain_url
+
+    if not publish:
       return self.error(
         'Publish is not enabled for your account(s). Please visit %s and sign up!' %
         ' or '.join(s.bridgy_url(self) for s in sources))

--- a/publish.py
+++ b/publish.py
@@ -89,6 +89,8 @@ class Handler(webmention.WebmentionHandler):
 
   shortlink = None
 
+  source = None
+
   def authorize(self):
     """Returns True if the current user is authorized for this request.
 
@@ -163,25 +165,25 @@ class Handler(webmention.WebmentionHandler):
       return self.error("Could not find <b>%(type)s</b> account for <b>%(domain)s</b>. Check that your %(type)s profile has %(domain)s in its <em>web site</em> or <em>link</em> field, then try signing up again." %
         {'type': source_cls.GR_CLASS.NAME, 'domain': domain})
 
-    publish = False
-    previous_url = ""
+    current_url = ''
     for source in sources:
       logging.info('Source: %s , features %s, status %s, poll status %s',
                    source.bridgy_url(self), source.features, source.status,
                    source.poll_status)
       if source.status != 'disabled' and 'publish' in source.features:
-        publish = True
-        # start with the first provided source, then check the rest for
-        # closer matches between the current url and provided domain_urls.
-        if previous_url == "":
+        # use a source that has a domain_url matching the url provided.
+        # look through each source to find the one with the closest match.
+        for domain_url in source.domain_urls:
+          if (url.lower().startswith(domain_url.lower().strip('/')) and
+              len(domain_url) > len(current_url)):
+            self.source = source
+            current_url = domain_url
+        # if there are no domain_urls and self.source is not set, allow this
+        # source to be used but keep looking for an actual match.
+        if (not source.domain_urls and not self.source):
           self.source = source
 
-        for domain_url in source.domain_urls:
-          if (url.startswith(domain_url) and len(domain_url) > len(previous_url)):
-            self.source = source
-            previous_url = domain_url
-
-    if not publish:
+    if not self.source:
       return self.error(
         'Publish is not enabled for your account(s). Please visit %s and sign up!' %
         ' or '.join(s.bridgy_url(self) for s in sources))

--- a/publish.py
+++ b/publish.py
@@ -178,10 +178,6 @@ class Handler(webmention.WebmentionHandler):
               len(domain_url) > len(current_url)):
             self.source = source
             current_url = domain_url
-        # if there are no domain_urls and self.source is not set, allow this
-        # source to be used but keep looking for an actual match.
-        if (not source.domain_urls and not self.source):
-          self.source = source
 
     if not self.source:
       return self.error(

--- a/test/test_facebook.py
+++ b/test/test_facebook.py
@@ -634,6 +634,7 @@ class FacebookPageTest(testutil.ModelsTest):
   def test_publish_person_tags(self):
     self.fb.features = ['publish']
     self.fb.domains = ['foo.com']
+    self.fb.domain_urls = ['http://foo.com/']
     self.fb.put()
 
     input_urls, _ = self.prepare_person_tags()

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -1124,5 +1124,17 @@ Join us!"""
     source_3.put()
     self.expect_requests_get('http://foo.com/bar', self.post_html % 'foo')
     self.mox.ReplayAll()
-    resp = self.assert_created('foo - http://foo.com/bar', interactive=False)
+    self.assert_created('foo - http://foo.com/bar', interactive=False)
     self.assertEquals(source_2.key, Publish.query().get().source)
+
+  def test_multiple_users_only_one_registered(self):
+    self.source.key.delete()
+    source_2 = testutil.FakeSource(
+      id='foo.com/b', features=['publish'], domains=['foo.com'],
+      auth_entity=self.auth_entity.key)
+    source_2.put()
+    source_3 = testutil.FakeSource(
+      id='foo.com/c', features=['publish'], domains=['foo.com'],
+      domain_urls=['http://foo.com/c'], auth_entity=self.auth_entity.key)
+    source_3.put()
+    self.assert_error('Publish is not enabled')

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -385,7 +385,7 @@ foo
 
   def test_source_url_is_domain_url(self):
     self.source.put()
-    self.assert_error("Looks like that's your home page.", source='https://foo.com#')
+    self.assert_error("Looks like that's your home page.", source='http://foo.com#')
 
     # query params alone shouldn't trigger this
     self.expect_requests_get('http://foo.com/?p=123', self.post_html % 'foo')

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -1113,7 +1113,7 @@ Join us!"""
     self.mox.ReplayAll()
     self.assert_success('going to Homebrew', preview=True)
 
-  def test_multiple_users_on_domin(self):
+  def test_multiple_users_on_domain(self):
     source_2 = testutil.FakeSource(
       id='foo.com/b', features=['publish'], domains=['foo.com'],
       domain_urls=['http://foo.com/b'], auth_entity=self.auth_entity.key)

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -1038,6 +1038,7 @@ Join us!"""
   def test_facebook_comment_and_like_disabled(self):
     self.source = facebook.FacebookPage(id='789', features=['publish'],
                                         domains=['mr.x'])
+    self.source.domain_urls = ['http://mr.x/']
     self.source.put()
 
     self.expect_requests_get('http://mr.x/like', """
@@ -1111,3 +1112,18 @@ Join us!"""
     self.mox.StubOutWithMock(self.source.gr_source, 'create', use_mock_anything=True)
     self.mox.ReplayAll()
     self.assert_success('going to Homebrew', preview=True)
+
+  def test_multiple_users_on_domin(self):
+    source_2 = testutil.FakeSource(
+      id='foo.com/b', features=['publish'], domains=['foo.com'],
+      domain_urls=['http://foo.com/b'], auth_entity=self.auth_entity.key)
+    source_2.put()
+    source_3 = testutil.FakeSource(
+      id='foo.com/c', features=['publish'], domains=['foo.com'],
+      domain_urls=['http://foo.com/c'], auth_entity=self.auth_entity.key)
+    source_3.put()
+    self.expect_requests_get('http://foo.com/bar', self.post_html % 'foo')
+    self.mox.ReplayAll()
+    resp = self.assert_created('foo - http://foo.com/bar', interactive=False)
+    publish = Publish.query().get()
+    self.assertEquals(source_2.key, publish.source)

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -1125,5 +1125,4 @@ Join us!"""
     self.expect_requests_get('http://foo.com/bar', self.post_html % 'foo')
     self.mox.ReplayAll()
     resp = self.assert_created('foo - http://foo.com/bar', interactive=False)
-    publish = Publish.query().get()
-    self.assertEquals(source_2.key, publish.source)
+    self.assertEquals(source_2.key, Publish.query().get().source)


### PR DESCRIPTION
Multiple users on the same domain are differentiated by url paths. This change allows bridgy to identify the correct user by comparing the `url` provided with `domain_urls` it has registered.