### PR TITLE
Facebook: infer app-scoped user ids like we infer usernames

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -23,8 +23,6 @@ __author__ = ['Ryan Barrett <bridgy@ryanb.org>']
 import heapq
 import json
 import logging
-import re
-import sys
 import urllib2
 import urlparse
 
@@ -91,6 +89,9 @@ class FacebookPage(models.Source):
   username = ndb.StringProperty()
   # inferred from syndication URLs if username isn't available
   inferred_username = ndb.StringProperty()
+  # inferred application-specific user IDs (from other applications)
+  inferred_app_scoped_user_ids = ndb.StringProperty(repeated=True)
+
   # maps string FB post id to string FB object id or None. background:
   # https://github.com/snarfed/bridgy/pull/513#issuecomment-149312879
   resolved_object_ids_json = ndb.TextProperty(compressed=True)
@@ -216,9 +217,9 @@ class FacebookPage(models.Source):
         if object_id:
           url = post_url(object_id)
 
-    username = self.username or self.inferred_username
-    if username:
-      url = url.replace('facebook.com/%s/' % username,
+    for alternate_id in filter(None, [self.username or self.inferred_username]
+                               + self.inferred_app_scoped_user_ids):
+      url = url.replace('facebook.com/%s/' % alternate_id,
                         'facebook.com/%s/' % self.key.id())
 
     return super(FacebookPage, self).canonicalize_url(url)
@@ -341,11 +342,17 @@ class FacebookPage(models.Source):
     # https://www.facebook.com/help/105399436216001
     author_id = self.gr_source.base_object({'object': {'url': url}})\
                               .get('author', {}).get('id')
-    if author_id and not util.is_int(author_id):
-      logging.info('Inferring username %s from syndication url %s', author_id, url)
-      self.inferred_username = author_id
-      self.put()
-      syndpost.syndication = self.canonicalize_url(syndpost.syndication)
+    if author_id:
+      if not util.is_int(author_id):
+        logging.info('Inferring username %s from syndication url %s', author_id, url)
+        self.inferred_username = author_id
+        self.put()
+        syndpost.syndication = self.canonicalize_url(syndpost.syndication)
+      elif author_id != self.key.id():
+        logging.info('Inferring app-scoped user id %s from syndication url %s', author_id, url)
+        self.inferred_app_scoped_user_ids.append(author_id)
+        self.put()
+        syndpost.syndication = self.canonicalize_url(syndpost.syndication)
 
 
 class AuthHandler(util.Handler):

--- a/test/test_facebook.py
+++ b/test/test_facebook.py
@@ -358,7 +358,7 @@ class FacebookPageTest(testutil.ModelsTest):
     self.expect_api_call('212038_444', {})
     self.mox.ReplayAll()
 
-    self.fb.inferred_app_scoped_user_ids.append('101008675309')
+    self.fb.inferred_user_ids.append('101008675309')
     self.assertEqual('https://www.facebook.com/212038/posts/444',
                      self.fb.canonicalize_url(
                        'https://www.facebook.com/101008675309/posts/444'))
@@ -497,7 +497,7 @@ class FacebookPageTest(testutil.ModelsTest):
       self.fb, original='http://aga.in',
       syndication='https://www.facebook.com/101008675309/posts/456')
     self.assertEquals(['101008675309'],
-                      fb.key.get().inferred_app_scoped_user_ids)
+                      fb.key.get().inferred_user_ids)
     self.assertEquals('https://www.facebook.com/212038/posts/456',
                       syndpost.syndication)
 

--- a/util.py
+++ b/util.py
@@ -31,7 +31,7 @@ from google.appengine.ext import ndb
 # when running in dev_appserver, replace these domains in links with localhost
 LOCALHOST_TEST_DOMAINS = frozenset([
   ('snarfed.org', 'localhost'),
-  ('kylewm.com', 'redwind.dev'),
+  ('kylewm.com', 'known.dev'),
 ])
 
 EPOCH = datetime.datetime.utcfromtimestamp(0)


### PR DESCRIPTION
When other applications posse to Facebook, they generally create
URLs with user-ids scoped to *that* application. These URLs make
no sense to Bridgy. This change canonicalizes them to Bridgy's user
ID for that user, just like we do for usernames.

Open question: does this cause problems if you POSSE to multiple 
Facebook accounts (e.g. kyle.mahan and indiewebcamp). Bridgy will 
be overly generous in classifying syndication links to one as syndication 
links to both, but since the post ID part of the URL will always be unique, 
I don't think this will cause any actual harm.

ref #375, #650 