### PR TITLE
migrate facebook API from v2.2 to v2.6

### DIFF
--- a/app.py
+++ b/app.py
@@ -308,6 +308,7 @@ class UserHandler(DashboardHandler):
             'rsvp-yes': 'is attending',
             'rsvp-no': 'is not attending',
             'rsvp-maybe': 'might attend',
+            'rsvp-interested': 'is interested',
             'invite': 'is invited',
           }
           r.response['content'] = '%s %s.' % (

--- a/templates/about.html
+++ b/templates/about.html
@@ -880,7 +880,7 @@ v2.x API</a>
 it much harder</a> to map backward from a Facebook post's URL to its API object
 id, and even when you can, the API usually won't let you read the post or like
 or comment on it. You need
-the <a href="https://developers.facebook.com/docs/facebook-login/permissions/v2.2#reference-read_stream"><code>read_stream</code>
+the <a href="https://developers.facebook.com/docs/facebook-login/permissions/#reference-read_stream"><code>read_stream</code>
 permission</a>, which Facebook only gives out in very rare circumstances.</p>
 
 <p><a href="https://github.com/snarfed/bridgy/issues/350">Lots more gory details

--- a/templates/choose_facebook.html
+++ b/templates/choose_facebook.html
@@ -15,7 +15,7 @@
              {% if forloop.first %} checked {% endif %}>
       <label for="{{ obj.id }}">
         <a target="_blank" href="https://www.facebook.com/{{ obj.id }}">
-          <img src="https://graph.facebook.com/v2.2/{{ obj.id }}/picture?width=32"
+          <img src="https://graph.facebook.com/v2.6/{{ obj.id }}/picture?width=32"
                class="profile" />
           {{ obj.name }}</a>
       </label>

--- a/test/test_original_post_discovery.py
+++ b/test/test_original_post_discovery.py
@@ -5,6 +5,7 @@ import datetime
 import json
 import string
 
+from granary import facebook as gr_facebook
 from oauth_dropins import facebook as oauth_facebook
 from requests.exceptions import HTTPError
 
@@ -1395,8 +1396,10 @@ class OriginalPostDiscoveryTest(testutil.ModelsTest):
       <a class="u-syndication" href="http://facebook.com/snarfed.org/posts/314159"></a>
     </html>""")
 
-    self.expect_urlopen(
-      'https://graph.facebook.com/v2.2/212038_314159?access_token=my_token', '{}')
+    self.expect_urlopen(gr_facebook.API_BASE +
+                        gr_facebook.API_OBJECT % ('212038', '314159') +
+                        '&access_token=my_token',
+                        '{}')
 
     self.mox.ReplayAll()
     self.assert_discover(['http://author/post/permalink'], source=fb)


### PR DESCRIPTION
most of the work is in snarfed/granary#87. this just updates some tests and HTML form values.

https://developers.facebook.com/docs/apps/changelog#v2_6