### PR TITLE
Comment about duplicate webmention endpoints

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -1100,6 +1100,10 @@ it to your blog.</p>
 <li><code>https://brid.gy/webmention/wordpress</code></li>
 </ul>
 </li>
+<p><strong>Nota Bene:</strong> Those using the IndieWeb Plugin (with the WebMention Plugin) with WordPress.org code likely 
+already have WebMention endpoints coded into their site automatically. Adding the code above a second time may cause some 
+webmentions to fail. Look for one of the following alternates:<br /><code><link rel="http://webmention.org/" href="http://yoursitename.com/?webmention=endpoint" /></code><br />
+<code><link rel="webmention" href="http://yoursitename.com/?webmention=endpoint" /></code><br />to ensure you're covered.</p>
 
 <li id="disqus" class="question">I'm on Tumblr. Why do I have to install
 <a href="http://disqus.com/">Disqus</a>?</li>


### PR DESCRIPTION
In relation to https://github.com/snarfed/bridgy/issues/682
You may want to tweak the broader WordPress(.ORG) workflow so the extra endpoint isn't suggested. If nothing else this will serve as a reminder/temporary patch in the meantime.