### PR TITLE
Change to improve contrast and pass ACAG AAA

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -81,7 +81,7 @@ pre .value, code.value {
 }
 
 pre .link, code.link {
-  color: #428BCA;
+  color: #12a;
 }
 
 .row {
@@ -206,14 +206,14 @@ code {
 
 label {
   /* override Bootstrap style */
-  font-weight: 200;
+  font-weight: 400;
 }
 
 button {
   border: 0;
-  background-color: #428BCA;  /* same color as links */
+  background-color: #12A;  /* same color as links */
   color: white;
-  font-weight: 200;
+  font-weight: 400;
   padding-top: .2em;
   padding-bottom: .2em;
   padding-left: .5em;
@@ -236,14 +236,14 @@ button[disabled]:hover {
 }
 
 .btn-default {
-  border-color: #428BCA;
-  color: #428BCA;
+  border-color: #12A;
+  color: #12A;
 }
 
 .btn-default:hover {
   background-color: #BDE;
-  border-color: #428BCA;
-  color: #428BCA;
+  border-color: #12A;
+  color: #12A;
 }
 
 #delete-button, #bad-button {


### PR DESCRIPTION
Darken blue on links and buttons from #428bca to #12a, improving contrast from 3.6 to 11.2
Remove the font-weight: 200 that was triggering the use of Roboto Thin on Android, making the type very low contrast on high dpi screens.