### PR TITLE
mention u-syndication when omitting link

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -1012,6 +1012,8 @@ the <code>u-bridgy-omit-link</code> class to a link in your post.</p>
 equivalent to sending a webmention with the query parameter <code>bridgy_omit_link=maybe</code>
 or including an element like <code>&lt;data class="p-bridgy-omit-link" value="maybe" /&gt;</code>
 in the post body.</p>
+<p>Please note that if you omit the link and want Bridgy to report back responses to your posts, 
+it needs <a href="#link">additional markup</a> to find the corresponding post on your website.</p>
 </li>
 
 <li id="ignore-formatting" class="question">Can I disable the plain text


### PR DESCRIPTION
A user we recently helped in IRC did start with omitted links, and didn't realize the additional requirements for backfeed when doing so. This just adds a link to relevant section of the document to make this easier to discover.