### PR TITLE
Fix links

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -1059,7 +1059,7 @@ I have something to say about this:
 <p>To create an issue, link to the repo with class <code><a href="http://microformats.org/wiki/rel-in-reply-to">u-in-reply-to</a></code>. For example:
 
 <pre>&lt;div class="<span class='keyword'>h-entry</span>"&gt;
-  &lt;a class="<span class='keyword'>u-in-reply-to</span>" href="<a href=https://github.com/snarfed/bridgy'>https://github.com/snarfed/bridgy</a>"&gt;Regarding Bridgy:&lt;/a&gt;
+  &lt;a class="<span class='keyword'>u-in-reply-to</span>" href="<a href='https://github.com/snarfed/bridgy'>https://github.com/snarfed/bridgy</a>"&gt;Regarding Bridgy:&lt;/a&gt;
   &lt;h1 class="<span class='keyword'>p-name</span>"&gt;<span class='value'>Please add support for <a href="https://www.justyo.co">Yo</a></span>&lt;/h1&gt;
   &lt;p class="<span class='keyword'>e-content</span>"&gt;<span class='value'>It's my favorite silo!</span>&lt;/p&gt;
 &lt;/div&gt;
@@ -1074,7 +1074,7 @@ I have something to say about this:
 <li class="answer">
 <p><a href="#github-issue-comment">Post a comment</a> where the content is 👍, 👎, 😆, 😕, ❤️, or 🎉. For example:</p>
 <pre>&lt;div class="<span class='keyword'>h-entry</span>"&gt;
-  &lt;a class="<span class='keyword'>u-in-reply-to</span>" href="<a href=https://github.com/snarfed/bridgy'>https://github.com/snarfed/bridgy/issues/333</a>"&gt;Regarding bridgy#333:&lt;/a&gt;
+  &lt;a class="<span class='keyword'>u-in-reply-to</span>" href="<a href='https://github.com/snarfed/bridgy'>https://github.com/snarfed/bridgy/issues/333</a>"&gt;Regarding bridgy#333:&lt;/a&gt;
   &lt;p class="<span class='keyword'>e-content</span>"&gt;<span class='value'>😆</span>&lt;/p&gt;
 &lt;/div&gt;
 </pre>


### PR DESCRIPTION
Those two links show up as `https://github.com/snarfed/bridgy'` with an additional single quote at the end.