### PR TITLE
issues should be in-reply-to a repo's issues page

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -1000,16 +1000,16 @@ I have something to say about this:
 
 <li id="github-issue-comment" class="question">How do I create a GitHub issue or comment?</li>
 <li class="answer">
-<p>To create an issue, link to the repo with class <code><a href="http://microformats.org/wiki/rel-in-reply-to">u-in-reply-to</a></code>. For example:
+<p>To create an issue, link to the repo’s issues page with class <code><a href="https://indieweb.org/u-in-reply-to">u-in-reply-to</a></code>. For example:
 
 <pre>&lt;div class="<span class='keyword'>h-entry</span>"&gt;
-  &lt;a class="<span class='keyword'>u-in-reply-to</span>" href="<a href='https://github.com/snarfed/bridgy'>https://github.com/snarfed/bridgy</a>"&gt;Regarding Bridgy:&lt;/a&gt;
+  &lt;a class="<span class='keyword'>u-in-reply-to</span>" href="<a href='https://github.com/snarfed/bridgy/issues'>https://github.com/snarfed/bridgy/issues</a>"&gt;Regarding Bridgy:&lt;/a&gt;
   &lt;h1 class="<span class='keyword'>p-name</span>"&gt;<span class='value'>Please add support for <a href="https://www.justyo.co">Yo</a></span>&lt;/h1&gt;
   &lt;p class="<span class='keyword'>e-content</span>"&gt;<span class='value'>It's my favorite silo!</span>&lt;/p&gt;
 &lt;/div&gt;
 </pre>
 </p>
-<p>To create a comment, use an <code>u-in-reply-to</code> link to the issue or pull request you want to comment on, instead of to the repo.
+<p>To create a comment, use an <code>u-in-reply-to</code> link to the issue or pull request you want to comment on, instead of to the repo’s issues page.
 </p>
 <p>If you're a <a href="https://help.github.com/articles/permission-levels-for-a-user-account-repository/#collaborator-access-on-a-repository-owned-by-a-user-account">collaborator on the repo</a>, you can attach <a href="https://help.github.com/articles/labeling-issues-and-pull-requests/">labels</a> to issues you create by including them as <a href="https://indieweb.org/tags">tags</a> in your post, e.g. <code>&lt;p class="<span class='keyword'>p-category</span>"&gt;<span class='value'>extra special</span>&lt;/p&gt;</code>. Bridgy will ignore tags that don't match existing labels, and it will ignore all tags if you don't have permission to add labels to issues in the repo.</p>
 </li>


### PR DESCRIPTION
issues should be in-reply-to a repo's issues page, also link to indieweb u-in-reply-to instead of microformats rel page