### PR TITLE
Fix: Request Publish scopes on sign-in

### DIFF
--- a/meetup.py
+++ b/meetup.py
@@ -63,7 +63,7 @@ class AddMeetup(oauth_meetup.CallbackHandler, util.Handler):
 
 ROUTES = [
   ('/meetup/start', util.oauth_starter(oauth_meetup.StartHandler).to(
-    '/meetup/add', scopes=LISTEN_SCOPES)),
+    '/meetup/add', scopes=PUBLISH_SCOPES)), # we don't support listen
   ('/meetup/add', AddMeetup),
   ('/meetup/delete/finish', oauth_meetup.CallbackHandler.to('/delete/finish')),
   ('/meetup/publish/start', oauth_meetup.StartHandler.to(


### PR DESCRIPTION
If we don't request `PUBLISH_SCOPES` on the initial login, you then have
to go through the Publish authorization flow before RSVPing to an event,
otherwise you'll receive 400s with `insufficient_scope`.

This isn't the nicest UX, so we should instead request the
`PUBLISH_SCOPES` up-front, as we don't support Listen, anyway.

Follow-up to #873.