### PR TITLE
Fix: Escape HTML tags in content

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -348,7 +348,7 @@ class Handler(webmention.WebmentionHandler):
       prop = microformats2.first_props(item.get('properties', {}))
       content = microformats2.get_text(prop.get('content'))
       if content:
-        obj['content'] = content.strip()
+        obj['content'] = content.strip().replace('<', '&lt;').replace('>', '&gt;')
 
     # which original post URL to include? in order of preference:
     # 1. rel-shortlink (background: https://github.com/snarfed/bridgy/issues/173)


### PR DESCRIPTION
As part of #880, we added a check to ensure that we would not be subject
to Cross-Site Scripting attacks (XSS).

However, as noted in #936, a post that does contain HTML is still being
rejected.

The simplest way to get around this is to escape the tags with the HTML
entities corresponding with them, so they can be safely rendered.

Closes #936.