### PR TITLE
Use site: search token for Reddit.

### DIFF
--- a/reddit.py
+++ b/reddit.py
@@ -66,7 +66,8 @@ class Reddit(models.Source):
     if not urls:
       return []
 
-    url_query = ' OR '.join([f'"{u}"' for u in urls])
+    # Search syntax: https://www.reddit.com/wiki/search
+    url_query = ' OR '.join([f'site:"{u}" OR selftext:"{u}"' for u in urls])
     return self.get_activities(
       search_query=url_query, group_id=gr_source.SEARCH, etag=self.last_activities_etag,
       fetch_replies=True, fetch_likes=False, fetch_shares=False, count=50)


### PR DESCRIPTION
The previous search would not find results submitted to the site if the post title or text didn't contain the domain. This updates the search to include the submitted URL in the search. It also excludes the title from the search as that can't be a real link and IIUC will not actually be actioned upon by brid.ly anyways. Note that there is no guarantee that a `selftext:` match actually contains a link however the false-positives will be filtered out when searching for links to send the webmention.

Examples:

- https://www.reddit.com/search?q=%22kevincox.ca%22&t=all
- https://www.reddit.com/search?q=site%3A%22kevincox.ca%22&t=all
- https://www.reddit.com/search?q=selftext%3A%22kevincox.ca%22&t=all
- https://www.reddit.com/search?q=site%3A%22kevincox.ca%22+OR+selftext%3Akevincox.ca&t=all