### PR TITLE
rm zombie site link

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -200,7 +200,7 @@ access to any of your passwords.
 <li class="answer">
 <p>
 We're <a class="h-card" href="https://snarfed.org/">Ryan Barrett</a>,
-<a class="h-card" href="https://kylewm.com/">Kyle Mahan</a>, and
+<span class="h-card">Kyle Mahan</span>, and
 <a href="https://github.com/snarfed/bridgy/graphs/contributors">many other
 contributors</a>. We're just normal people who
 <a href="https://snarfed.org/2012-07-25_why_i_have_my_own_web_site">like the


### PR DESCRIPTION
minimal change to immediately stop linking to a zombie domain