### PR TITLE
editorial, link text closer to destination

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -202,9 +202,9 @@ access to any of your passwords.
 We're <a class="h-card" href="https://snarfed.org/">Ryan Barrett</a>,
 <a class="h-card" href="https://github.com/kylewm">Kyle Mahan</a>, and
 <a href="https://github.com/snarfed/bridgy/graphs/contributors">many other
-contributors</a>. We're just normal people who
-<a href="https://snarfed.org/2012-07-25_why_i_have_my_own_web_site">like the
-web</a> and like <a href="https://indieweb.org/why">owning our data</a>.
+contributors</a>. We 
+<a href="https://snarfed.org/2012-07-25_why_i_have_my_own_web_site">like using
+our own websites</a> and <a href="https://indieweb.org/why">owning our data</a>.
 </p>
 </li>
 


### PR DESCRIPTION
minor editorial suggestions. 
dropping "just" as a general stylistic guide.
reference to "normal people" didn't feel necessary and could be non-inclusive.
be up front about liking using our own websites