### PR TITLE
adding follow_meta_refresh to webmention discover

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -592,7 +592,7 @@ class SendWebmentions(View):
         # send! and handle response or error
         headers = util.request_headers(source=g.source)
         if not endpoint:
-          endpoint, resp = webmention.discover(target, headers=headers)
+          endpoint, resp = webmention.discover(target, follow_meta_refresh=True, headers=headers)
           with util.webmention_endpoint_cache_lock:
             util.webmention_endpoint_cache[cache_key] = endpoint or NO_ENDPOINT
 


### PR DESCRIPTION
Added follow_meta_refresh to do_send_webmentions function for [#253](https://github.com/snarfed/bridgy/issues/253).
This is for the purpose of following client-side redirects when a link that needs to be redirected to its endpoint via client side is present in a post.

Please let me know if anything else should be added (like tests and such).