### PR TITLE
add bugs & feedback to text

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -449,8 +449,9 @@ Here are the properties Bridgy uses:
 
 <li id="bug" class="question">I found a bug! I have a feature request!</li>
 <li class="answer">
-<p>Great! Please <a href="https://github.com/snarfed/bridgy/issues">file it in
-GitHub</a>. Thank you!
+<p>Great! Please 
+   <a href="https://github.com/snarfed/bridgy/issues">file bugs, suggestions, and feedback in GitHub</a>.
+   Thank you!
 </p>
 </li>
 


### PR DESCRIPTION
discoverability improvement, add "bugs" and "feedback" (words previously absent from the page) explicitly to GitHub issues link for folks that might do a page-search for those words. also line-breaks around the hyperlink