### PR TITLE
Add Bridgy source post_id method

### DIFF
--- a/bluesky.py
+++ b/bluesky.py
@@ -64,11 +64,9 @@ class Bluesky(models.Source):
 
   def post_id(self, url):
     if url.startswith('at://'):
-      if url.startswith(f'at://{self.username}'):
-        # Bluesky can't currently resolve AT URIs containing handles,
-        # even though they are technically valid. Replace it with DID.
-        return url.replace(f'at://{self.username}', f'{at://self.key_id()}')
-      return url
+      # Bluesky can't currently resolve AT URIs containing handles,
+      # even though they are technically valid. Replace it with DID.
+      return url.replace(f'at://{self.username}', f'at://{self.key_id()}')
     return gr_bluesky.web_url_to_at_uri(url, did=self.key_id(), handle=self.username)
 
   @classmethod

--- a/bluesky.py
+++ b/bluesky.py
@@ -10,6 +10,7 @@ from urllib.parse import quote
 
 logger = logging.getLogger(__name__)
 
+
 class Bluesky(models.Source):
   """
   A Bluesky account.

--- a/bluesky.py
+++ b/bluesky.py
@@ -67,7 +67,7 @@ class Bluesky(models.Source):
       if url.startswith(f'at://{self.username}'):
         # Bluesky can't currently resolve AT URIs containing handles,
         # even though they are technically valid. Replace it with DID.
-        return url.replace(self.username, self.key_id())
+        return url.replace(f'at://{self.username}', f'{at://self.key_id()}')
       return url
     return gr_bluesky.web_url_to_at_uri(url, did=self.key_id(), handle=self.username)
 

--- a/bluesky.py
+++ b/bluesky.py
@@ -10,7 +10,6 @@ from urllib.parse import quote
 
 logger = logging.getLogger(__name__)
 
-
 class Bluesky(models.Source):
   """
   A Bluesky account.
@@ -61,6 +60,15 @@ class Bluesky(models.Source):
     They do not need to be decoded correspondingly.
     """
     return quote(quote(id, safe=''))
+
+  def post_id(self, url):
+    if url.startswith('at://'):
+      if url.startswith(f'at://{self.username}'):
+        # Bluesky can't currently resolve AT URIs containing handles,
+        # even though they are technically valid. Replace it with DID.
+        return url.replace(self.username, self.key_id())
+      return url
+    return gr_bluesky.web_url_to_at_uri(url, did=self.key_id(), handle=self.username)
 
   @classmethod
   def button_html(cls, feature):

--- a/models.py
+++ b/models.py
@@ -303,6 +303,14 @@ class Source(StringIdModel, metaclass=SourceMeta):
     """Human-readable name or username for this source, whichever is preferred."""
     return self.name or self.key_id()
 
+  def post_id(self, url):
+    """
+    Resolve the ID of a post from a URL.
+    By default calls out to Granary's classmethod but can be
+    overridden if a URL needs user-specific treatment.
+    """
+    return self.gr_source.post_id(url)
+
   @classmethod
   @ndb.transactional()
   def put_updates(cls, source):

--- a/pages.py
+++ b/pages.py
@@ -481,7 +481,7 @@ def discover():
 
   gr_source = source.gr_source
   if domain == gr_source.DOMAIN:
-    post_id = gr_source.post_id(url)
+    post_id = source.post_id(url)
     if post_id:
       type = 'event' if path.startswith('/events/') else None
       util.add_discover_task(source, post_id, type=type)
@@ -492,7 +492,7 @@ def discover():
     synd_links = original_post_discovery.process_entry(source, url, {}, False, [])
     if synd_links:
       for link in synd_links:
-        util.add_discover_task(source, gr_source.post_id(link))
+        util.add_discover_task(source, source.post_id(link))
       source.updates = {'last_syndication_url': util.now()}
       models.Source.put_updates(source)
     else:

--- a/tests/test_bluesky.py
+++ b/tests/test_bluesky.py
@@ -53,3 +53,9 @@ class BlueskyTest(testutil.AppTest):
     good = 'https://bsky.app/profile/alice.com'
     self.assertEqual(good, self.bsky.canonicalize_url(good))
     self.assertEqual(good, self.bsky.canonicalize_url('http://bsky.app/profile/alice.com'))
+
+  def test_post_id(self):
+    good = 'at://did:web:alice.com/app.bsky.feed.post/123'
+    self.assertEqual(good, self.bsky.post_id(good))
+    self.assertEqual(good, self.bsky.post_id('at://alice.com/app.bsky.feed.post/123'))
+    self.assertEqual(good, self.bsky.post_id('https://bsky.app/profile/alice.com/post/123'))


### PR DESCRIPTION
Went with a source-specific post_id method that by default just calls through to the static Granary one but can be overridden on a per-silo basis.

Fixes #1575