### PR TITLE
Remove unconfigured/unused action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -59,6 +59,3 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
-
-    - name: DefenseCode ThunderScan Action
-      uses: defensecode/thunderscan-action@v1.0


### PR DESCRIPTION
defensecode/thunderscan-action requires an input (and software) and as such this step does nothing (beyond adding a dependency to your workflow)