### PR TITLE
Security: Missing CSRF Protection on State-Changing Operations

### DIFF
--- a/flask_app.py
+++ b/flask_app.py
@@ -11,6 +11,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from webutil import flask_util
 from webutil.appengine_config import ndb_client
 from webutil import appengine_info
+from flask_wtf.csrf import CSRFProtect
 
 import granary
 import appengine_config  # *after* import granary to override set_user_agent()
@@ -30,6 +31,9 @@ app.before_request(flask_util.canonicalize_domain(
   util.OTHER_DOMAINS, util.PRIMARY_DOMAIN))
 if appengine_info.LOCAL_SERVER and not appengine_info.TESTING:
   flask_gae_static.init_app(app)
+
+# CSRF protection for state-changing operations
+csrf = CSRFProtect(app)
 
 app.wsgi_app = flask_util.ndb_context_middleware(app.wsgi_app, client=ndb_client)
 


### PR DESCRIPTION
## Summary

Security: Missing CSRF Protection on State-Changing Operations

## Problem

**Severity**: `High` | **File**: `flask_app.py:L1`

Multiple POST endpoints that modify state (add/delete sources, publish, disable accounts) lack CSRF protection. The Flask app uses sessions with SESSION_COOKIE_SAMESITE='Lax' which provides some protection for cross-site requests, but does not protect against same-site CSRF attacks. Forms like /delete/start, /flickr/start, /github/start, /mastodon/start, /reddit/callback, /indieauth/start, and publish endpoints are vulnerable.

## Solution

Implement CSRF protection using Flask-WTF or similar. Add CSRF tokens to all state-changing forms and validate them on POST requests. Consider using the 'strict' SameSite policy for session cookies where possible.

## Changes

- `flask_app.py` (modified)